### PR TITLE
Document worker requirement on PGP

### DIFF
--- a/docs/concepts/worker-pools.md
+++ b/docs/concepts/worker-pools.md
@@ -125,6 +125,7 @@ In addition, you will also need to allow access to the following:
 - Your VCS provider.
 - Access to any custom container registries you use if using custom runner images.
 - Access to any other infrastructure required as part of your runs.
+- Access to `keys.openpgp.org` - required to download the PGP key used to sign Spacelift binaries.
 
 ## Using worker pools
 


### PR DESCRIPTION
# Description of the change

We download our public PGP key from keys.openpgp.org. This is used to verify the signature of the worker binary downloaded by the launcher.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

Thank you for your contribution! 🙇
