### PR TITLE
Show BBDC webhooks screenshot in webhooks section

### DIFF
--- a/docs/integrations/source-control/bitbucket-datacenter-server.md
+++ b/docs/integrations/source-control/bitbucket-datacenter-server.md
@@ -39,11 +39,13 @@ Once you have your access token, enter it into Spacelift. At this point all the 
 
 ![](<../../assets/screenshots/image (102).png>)
 
-After saving, you'll receive your webhook secret and endpoint:
-
-![](<../../assets/screenshots/image (103).png>)
+You can now save the integration.
 
 ### Configuring webhooks
+
+Once you have saved your integration, you'll receive your webhook secret and endpoint:
+
+![](<../../assets/screenshots/image (103).png>)
 
 For each repository you want to use with Spacelift, you need to go into its **Repository settings -> Webhooks -> Create webhook**, and configure the webhooks accordingly, by activating the following events:
 


### PR DESCRIPTION
# Description of the change

I've moved the screenshot showing the webhooks URL and secret into the "Configuring webhooks" section. Previously it was a little confusing when sending a direct link to someone because they wouldn't have the context of where to get this information.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
