### PR TITLE
changes wording

### DIFF
--- a/docs/concepts/policy/notification-policy.md
+++ b/docs/concepts/policy/notification-policy.md
@@ -418,7 +418,7 @@ section and providing that as the endpoint when creating a new [named webhook](.
     <!-- markdown-link-check-disable -->
     For more information about making Discord webhooks follow their [official webhook guide](https://support.discord.com/hc/en-us/articles/228383668){: rel="nofollow"}.
 
-After creating the webhook on both Discord and Spacelift you can define a new webhook rule like this:
+After creating the webhook on both Discord and Spacelift you will need to define a new webhook rule like this:
 
 ```opa
 # Send updates about tracked runs to discord.


### PR DESCRIPTION
# Description of the change

I changed the wording from "can" to "you will need to" because "can" seemed like it was optional, however if you do not configure it that way, it will result in a status code 400

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
