### PR TITLE
Fix module registry env typo

### DIFF
--- a/docs/concepts/configuration/context.md
+++ b/docs/concepts/configuration/context.md
@@ -58,7 +58,7 @@ Now this attached context will also contribute to the [stack environment](enviro
 
 ![](<../../assets/screenshots/Environment_·_Managed_stack (3).png>)
 
-...and be visible on the list of attached stacks:
+...and be visible on the list of attached contexts:
 
 ![](<../../assets/screenshots/Environment_·_Managed_stack (4).png>)
 

--- a/docs/vendors/terraform/module-registry.md
+++ b/docs/vendors/terraform/module-registry.md
@@ -94,7 +94,7 @@ The name and provider will be inferred from your repository name if it follows t
 
 ### Environment, contexts and policies
 
-[Environment](../../concepts/configuration/environment.md) and [context](../../concepts/configuration/context.md) management in modules is identical to that for [stacks](../../concepts/stack/README.md). The only thing worth noting here is the fact that environment variables and mounted files set either through the module environment directly, or via one of its attached stacks will be passed to each of the [test cases](module-registry.md#tests) for the module.
+[Environment](../../concepts/configuration/environment.md) and [context](../../concepts/configuration/context.md) management in modules is identical to that for [stacks](../../concepts/stack/README.md). The only thing worth noting here is the fact that environment variables and mounted files set either through the module environment directly, or via one of its attached contexts will be passed to each of the [test cases](module-registry.md#tests) for the module.
 
 Attaching policies works in a similar way. One thing worth pointing out is that the behavior of [Trigger policies](../../concepts/policy/trigger-policy.md#module-updates) are slightly different for modules. Instead of being provided with the list of all other accessible stacks, module trigger policies receive a list of the current consumers of the module. This allows you to automatically trigger dependent stacks when new module versions are published.
 


### PR DESCRIPTION
# Description of the change

Changing stacks to contexts in the module environment description - I think this is a typo 🙌 

Also noticed the same mistake in Context docs.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
