### PR TITLE
add nofollow rel to banner link

### DIFF
--- a/overrides/partials/banner.html
+++ b/overrides/partials/banner.html
@@ -9,7 +9,7 @@
         <a
           href="{{ config.extra.banner.cta_url }}"
           class="helloBannerLink"
-          rel="noopener noreferrer nofollow"
+          rel="noopener noreferrer{{ ' nofollow' if config.extra.banner.add_rel_nofollow else '' }}"
           target="_blank"
           >{{ config.extra.banner.cta_text }}</a
         >


### PR DESCRIPTION
# Description of the change

<!-- Please describe the changes that are being added by this PR -->

By default, all the CTA URLs from top banner shouldn't have `nofollow` attribute, and we need the ability to decide when we want to add it. 

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
