### PR TITLE
change source for top banner

### DIFF
--- a/docs/assets/css/extra.css
+++ b/docs/assets/css/extra.css
@@ -12,6 +12,7 @@ See Sass variables available: https://github.com/squidfunk/mkdocs-material/blob/
   --color-default-outline: #D1D2D9;
   --bg-dark: #171721;
   --color-gradient-dark: #70dfcd;
+  --color-info-light: #2e89f3;
   --top-banner-height: 40px;
 }
 
@@ -303,19 +304,13 @@ header .md-search__input {
   --main-container-padding: 0 100px;
   --small-main-container-padding: 0 20px;
 
-  background: linear-gradient(
-    45deg,
-    var(--color-gradient-dark),
-    var(--color-primary-main)
-  );
-
   height: var(--top-banner-height);
   padding: 10px 0;
   width: 100%;
   position: sticky;
   top: 0;
   color: var(--color-default-white);
-  z-index: 1;       
+  z-index: 1;
 }
 
 .helloBanner + header {
@@ -373,6 +368,18 @@ header .md-search__input {
   background-color: var(--color-default-white);
   transform-origin: bottom left;
   transition: transform 0.25s ease-out;
+}
+
+.helloBanner--gradient {
+  background: linear-gradient(
+    45deg,
+    var(--color-gradient-dark),
+    var(--color-primary-main)
+  );
+}
+
+.helloBanner--blue {
+  background-color: var(--color-info-light);
 }
 
 @media (max-width: 960px) {

--- a/hooks/fetch_banner.py
+++ b/hooks/fetch_banner.py
@@ -6,7 +6,7 @@ def on_config(config):
     if(wp_options_api_url):
         response = requests.get(wp_options_api_url)
         data = response.json()
-        banner = data['acf']['hello_banner']
+        banner = data['acf']['docs_banner']
         config['extra'].update({'banner': banner})
 
     return config

--- a/overrides/partials/banner.html
+++ b/overrides/partials/banner.html
@@ -1,4 +1,4 @@
-<div class="helloBanner">
+<div class="helloBanner {{'helloBanner--' + config.extra.banner.color}}">
   <div class="helloBannerContainer">
     <div class="helloBannerWrapper">
       {% if config.extra.banner.text %}


### PR DESCRIPTION
# Description of the change

<!-- Please describe the changes that are being added by this PR -->

The current banner is aligned across the website and docs. If we edit the message to promote our attendance at an event, for example, that is not relevant for docs, we want to separate the functionality, so we can update the website without updating docs (or vice versa).

Secondly, add support for `color` prop.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
