### PR TITLE
Add self-hosted docs support with Mike

### DIFF
--- a/docs/concepts/blueprint/README.md
+++ b/docs/concepts/blueprint/README.md
@@ -45,6 +45,8 @@ Choose `Blueprints` on the left menu and click on `Create blueprint`. As of now,
 
 The absolute minimum you'll need to provide is `name`, `space`, `vcs` and `vendor`; all others are optional. Here's a small working example:
 
+{% raw %}
+
 ```yaml
 inputs:
   - id: stack_name
@@ -62,6 +64,8 @@ stack:
       version: "1.3.0"
 ```
 
+{% endraw %}
+
 <p align="center" >
     <img src="../../assets/screenshots/blueprint_preview.png">
 </p>
@@ -75,6 +79,8 @@ Now, let's look at a massive example that covers all the available configuration
 
 <details> <!-- markdownlint-disable-line MD033 -->
 <summary>Click to expand</summary> <!-- markdownlint-disable-line MD033 -->
+
+{% raw %}
 
 ```yaml
 inputs:
@@ -226,6 +232,8 @@ stack:
       login_url: https://app.pulumi.com
 ```
 
+{% endraw %}
+
 </details>
 
 As you noticed if we attach an existing resource to the stack (such as Worker Pool, Cloud integration, Policy or Context) we use the unique identifier of the resource. Typically, there is a button for it in the UI but you can also find it in the URL of the resource.
@@ -256,19 +264,27 @@ There are reserved characters in YAML, such as `>` (multiline string) `|` (multi
 
 Invalid template:
 
+{% raw %}
+
 ```yaml
 stack:
   name: ${{ 2 > 1 ? "yes" : "no" }}-my-stack
 ```
 
+{% endraw %}
+
 See how the syntax highlighter is confused?
 
 Valid template:
+
+{% raw %}
 
 ```yaml
 stack:
   name: '${{ 2 > 1 ? "yes" : "no" }}-my-stack'
 ```
+
+{% endraw %}
 
 Results in:
 
@@ -283,13 +299,17 @@ Since you probably don't want to create stacks with the exact same name and conf
 
 ### Inputs
 
+{% raw %}
 Inputs are defined in the `inputs` section of the template. You can use them in the template by prefixing them with `${{ inputs.` and suffixing them with `}}`. For example, `${{ inputs.environment }}` will be replaced with the value of the `environment` input. You can use these variables in CEL functions as well. For example, `trigger_run: ${{ inputs.environment == 'prod' }}` will be replaced with `trigger_run: true` or `trigger_run: false` depending on the value of the `environment` input.
+{% endraw %}
 
 The input object has `id`, `name`, `description`, `type`, `default` and `options` fields. The mandatory fields are `id` and `name`.
 
 The `id` is used to refer to the input in the template. The `name` and the `description` are just helper fields for the user in the Stack creation tab. The `type` is the [type of the input](#input-types). The `default` is an optional default value of the input. The `options` is a list of options for the `select` input type.
 
 Example:
+
+{% raw %}
 
 ```yaml
 inputs:
@@ -298,6 +318,8 @@ inputs:
 stack:
   name: ${{ inputs.app_name }}-my-stack
 ```
+
+{% endraw %}
 
 #### Input types
 
@@ -367,6 +389,8 @@ We also provide an input object called `context`. It contains the following prop
 
 Here is an example of using a few of them:
 
+{% raw %}
+
 ```yaml
 stack:
   name: integration-tests-${{ inputs.app }}-${{ context.random_string }}
@@ -385,6 +409,8 @@ stack:
       delete_resources: ${{ context.random_number % 2 == 0 }} # Russian roulette
       timestamp_unix: ${{ int(context.time) + duration(30m).getSeconds() }} # Delete the stack in 30 minutes
 ```
+
+{% endraw %}
 
 Results in:
 
@@ -418,6 +444,8 @@ We do not validate drafted blueprints, you can do whatever you want with them. H
 
 **One caveat**: we cannot validate fields that have variables because we don't know the value of the variable. On the other hand, if you try to create a stack from the blueprint and supply the inputs to the template, we'll be able to do the full validation. Let's say:
 
+{% raw %}
+
 ```yaml
 inputs:
   - id: timestamp
@@ -428,6 +456,8 @@ stack:
     delete:
       timestamp_unix: ${{ inputs.timestamp }}
 ```
+
+{% endraw %}
 
 We cannot make sure that the input variable is indeed a proper 10 digit epoch timestamp, we will only find out once you supply the actual input.
 

--- a/docs/integrations/api.md
+++ b/docs/integrations/api.md
@@ -204,6 +204,8 @@ Copy the following JSON to your clipboard:
 
 ??? note "Click here to expand"
 
+{% raw %}
+
     ```json
     {
         "_type": "export",
@@ -348,6 +350,8 @@ Copy the following JSON to your clipboard:
         ]
     }
     ```
+
+{% endraw %}
 
 In the home screen of Insomnia, click on `Import From` then click on `Clipboard`.
 

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -1,0 +1,9 @@
+---
+description: Deploy Spacelift to your own AWS account!
+---
+
+# Spacelift Self-Hosting
+
+Alongside our SaaS product, we also provide a self-hosted version of Spacelift that you can install into an account that you control.
+
+You can find the documentation for the latest version of self-hosted [here](./self-hosted/latest/index.html)

--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -6,4 +6,4 @@ description: Deploy Spacelift to your own AWS account!
 
 Alongside our SaaS product, we also provide a self-hosted version of Spacelift that you can install into an account that you control.
 
-You can find the documentation for the latest version of self-hosted [here](./self-hosted/latest/index.html)
+You can find the documentation for the latest version of self-hosted [here](./self-hosted/latest)

--- a/docs/vendors/terraform/module-registry.md
+++ b/docs/vendors/terraform/module-registry.md
@@ -253,6 +253,8 @@ After you confirm that you want to proceed, Terraform will open your default web
 
 If you want to use [Dependabot](https://github.com/dependabot){: rel="nofollow"} to automatically update your module versions, you can use the following `dependabot.yml` [configuration](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates){: rel="nofollow"}:
 
+{% raw %}
+
 ```yaml
 version: 2
 registries:
@@ -268,5 +270,7 @@ updates:
     schedule:
       interval: "daily"
 ```
+
+{% endraw %}
 
 It is important for the `url` to be `https://app.spacelift.io` and for the `token` to be a [Spacelift API key](../../integrations/api.md#spacelift-api-key-token). Admin access is not required.

--- a/docs/vendors/terraform/provider-registry.md
+++ b/docs/vendors/terraform/provider-registry.md
@@ -119,6 +119,8 @@ In the _Register GPG key_ drawer, you will need to provide the name, the ASCII-a
 
 Now that you have a provider and a GPG key, you can set up your CI/CD tool to publish provider versions. First, let's set up the GoReleaser config file in your provider repository:
 
+{% raw %}
+
 ```yaml title=".goreleaser.yml"
 builds:
   - env: ['CGO_ENABLED=0']
@@ -151,11 +153,15 @@ release:
   disable: true
 ```
 
+{% endraw %}
+
 This setup assumes that the name of your project (repository) is `terraform-provider-$name`. If it is not (maybe you're using a monorepo?) then you will need to change the config accordingly, presumably by hardcoding the project name.
 
 Next, let's make sure you have an API key for the Spacelift account you want to publish the provider to. You can refer to the [API key management](../../integrations/api.md#spacelift-api-key--token) section of the API documentation for more information on how to do that. Note that the key you're generating **must** have admin access to the space that the provider lives in. If the provider is in the `root` space, then the key must have root admin access.
 
 We can now add a GitHub Actions workflow definition to our repository:
+
+{% raw %}
 
 ```yaml title=".github/workflows/release.yml"
 name: release
@@ -224,6 +230,8 @@ jobs:
         run: # Don't forget to change the provider type!
           spacectl provider create-version --type=TYPE-change-me!!!
 ```
+
+{% endraw %}
 
 If everything is fine, pushing a tag like `v0.1.0` should create a new **draft** version of the provider in Spacelift. You can list the versions of your provider using `spacectl`:
 

--- a/main.py
+++ b/main.py
@@ -1,0 +1,14 @@
+"""
+This is where we define additional macros for the MkDocs macros plugin.
+"""
+
+import os
+
+def define_env(env):
+    @env.macro
+    def is_self_hosted():
+        return env.variables.spacelift_distribution == "SELF_HOSTED"
+
+    @env.macro
+    def is_saas():
+        return not is_self_hosted()

--- a/markdown-link-check.json
+++ b/markdown-link-check.json
@@ -1,10 +1,7 @@
 {
   "httpHeaders": [
     {
-      "urls": [
-        "https://developer.github.com/",
-        "https://docs.github.com/"
-      ],
+      "urls": ["https://developer.github.com/", "https://docs.github.com/"],
       "headers": {
         "Accept-Encoding": "zstd, br, gzip, deflate"
       }
@@ -16,6 +13,9 @@
     },
     {
       "pattern": "^https://github.com/spacelift-io/user-documentation/"
+    },
+    {
+      "pattern": "^.+?/self-hosted/.*"
     }
   ]
 }

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,4 +1,4 @@
-INHERIT: ./nav.yaml
+INHERIT: !ENV [NAV_FILE, "./nav.yaml"]
 copyright: © 2022 Spacelift, Inc. All rights reserved
 site_author: Spacelift
 site_description: Collaborative Infrastructure For Modern Software Teams
@@ -63,5 +63,18 @@ extra:
     - icon: fontawesome/brands/facebook
       link: https://www.facebook.com/spaceliftio-103558488009736/
       name: Spacelift on Facebook
+  spacelift_distribution: !ENV [SPACELIFT_DISTRIBUTION, "SAAS"]
+  version:
+    provider: mike
 hooks:
   - hooks/fetch_banner.py
+plugins:
+  - search
+  - macros
+  - mike:
+      # These fields are all optional; the defaults are as below...
+      alias_type: symlink
+      redirect_template: null
+      deploy_prefix: ""
+      canonical_version: "latest"
+      version_selector: true

--- a/nav.self-hosted.yaml
+++ b/nav.self-hosted.yaml
@@ -51,7 +51,6 @@ nav:
           - concepts/spaces/deleting-a-space.md
           - concepts/spaces/structuring-your-spaces-tree.md
           - concepts/spaces/migrating-out-of-the-legacy-space.md
-      - concepts/vcs-agent-pools.md
   - 🛰️ Platforms:
       - Terraform:
           - vendors/terraform/README.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 mkdocs-material==8.5.11
+mkdocs-macros-plugin==1.0.1
+mike @ git+https://github.com/jimporter/mike.git


### PR DESCRIPTION
# Description of the change

This PR doesn't actually add any self-hosted docs to the repo, but it adds the following things:

- [Mike](https://github.com/jimporter/mike) - an MkDocs plugin that allows multiple versions of documentation to be published.
- [MkDocs Macros](https://mkdocs-macros-plugin.readthedocs.io/en/latest/) - allows us to use templates within documentation.
- A separate nav file for self-hosted.

I'll post further PRs with things like updates to the Render and GitHub Actions pipelines, along with docs explaining how to work on the self-hosted docs.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [ ] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
