### PR TITLE
Update builds for self-hosted

### DIFF
--- a/.github/workflows/deploy-to-environment.yaml
+++ b/.github/workflows/deploy-to-environment.yaml
@@ -12,6 +12,8 @@ on:
       environment_url:
         required: true
         type: string
+      deploy_self_hosted:
+        type: boolean
     secrets:
       AWS_REGION:
         required: true
@@ -39,6 +41,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Checkout Self-Hosted Releases
+        if: ${{ inputs.deploy_self_hosted }}
+        uses: actions/checkout@v3
+        with:
+          ref: self-hosted-releases
+          path: self-hosted-releases
+
       - name: Set Python up
         uses: actions/setup-python@v4
         with:
@@ -49,6 +58,14 @@ jobs:
 
       - name: Build documentation
         run: mkdocs build
+
+      - name: Copy self-hosted documentation
+        if: ${{ inputs.deploy_self_hosted }}
+        run: |
+          mkdir -p site/self-hosted
+          cp -r self-hosted-releases/latest site/self-hosted
+          cp -r self-hosted-releases/v* site/self-hosted
+          cp self-hosted-releases/versions.json site/self-hosted
 
       - name: Transform the URLs
         run: python ./scripts/transform_urls.py

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -13,6 +13,7 @@ jobs:
       environment_code: preprod
       environment_name: Pre-Production
       environment_url: https://docs.spacelift.dev/
+      deploy_self_hosted: true
     secrets:
       # KLUDGE: We are not actually passing the secrets here.
       # What we’re really doing is passing the key to the secret that we want the reusable workflow to use.

--- a/scripts/render-build.sh
+++ b/scripts/render-build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+rm -rf site
+mkdir -p site/self-hosted
+
+# Build the SaaS version of the site
+mkdocs build
+
+# Build the self-hosting version of the site
+NAV_FILE=./nav.self-hosted.yaml SPACELIFT_DISTRIBUTION=SELF_HOSTED mkdocs build -d site/self-hosted/latest


### PR DESCRIPTION
# Description of the change

- Updated the GitHub Actions workflow to deploy the self-hosted docs. At the moment we'll only deploy to preprod.
- Added a script we can call from Render to build a copy of the docs containing the latest version of both SaaS and self-hosted docs.

I've also temporarily pushed a version of the docs to a branch called `self-hosted-releases`. This is to allow us to test the workflow, but we can completely delete and recreate before releasing after making any required changes to the docs.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [ ] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
