### PR TITLE
Temporarily remove preview from PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,8 @@
 Please make sure that the proposed change checks all the boxes below before requesting a review:
 
 - [ ] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
-- [ ] The preview looks fine.
+<!-- TODO: re-add the preview once we setup Render again -->
+<!-- - [ ] The preview looks fine. -->
 - [ ] The tests pass.
 - [ ] The commit history is clean and meaningful.
 - [ ] The pull request is opened against the `main` branch.


### PR DESCRIPTION
# Description of the change

We need to temporarily disable the Render previews, so I'm removing it from the checklist to avoid confusion.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [ ] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
