### PR TITLE
Add self-hosted release workflow

### DIFF
--- a/.github/workflows/self-hosted-release.yaml
+++ b/.github/workflows/self-hosted-release.yaml
@@ -1,0 +1,102 @@
+name: Release new Self-Hosted version
+
+on:
+  push:
+    tags:
+      - self-hosted-v*
+
+# Make sure that we don't try to deploy from both this workflow and the main deployment workflow
+concurrency:
+  group: "deployment"
+
+env:
+  release_branch_name: "self-hosted-releases"
+
+jobs:
+  create-new-release:
+    name: "Create new self-hosted release"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: "Extract version number"
+        run: |
+          # Trim prefix from tag
+          VERSION=${GITHUB_REF_NAME/self-hosted-/}
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+
+      # Generate a token to use to checkout the code from our GitHub App. We need to use a
+      # GitHub App to allow us to push to the release branch without having to open a PR, bypassing
+      # branch protection rules.
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.SELF_HOSTED_RELEASER_BOT_APP_ID }}
+          private_key: ${{ secrets.SELF_HOSTED_RELEASER_BOT_APP_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Set Python up
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+
+      - name: Install Python Requirements
+        run: pip install --requirement requirements.txt
+
+      - name: "Fetch releases branch"
+        # This step could fail if the branch doesn't already exist, but that's fine because Mike will create it.
+        continue-on-error: true
+        run: |
+          git fetch origin ${{ env.release_branch_name }} --depth=1
+
+      - name: "Create release"
+        run: |
+          # Configure Git to allow Mike to commit to the release branch
+          git config user.name self-hosted-releases
+          git config user.email self-hosted-releases@spacelift.io
+
+          # Create release using Mike
+          mike deploy -u --branch ${{ env.release_branch_name }} ${VERSION} latest
+        env:
+          NAV_FILE: "./nav.self-hosted.yaml"
+          SPACELIFT_DISTRIBUTION: "SELF_HOSTED"
+
+      - name: "Push branch"
+        run: "git push origin self-hosted-releases:refs/heads/self-hosted-releases"
+
+  deploy-to-preprod:
+    name: Deploy to pre-production
+    uses: ./.github/workflows/deploy-to-environment.yaml
+    needs: create-new-release
+    with:
+      environment_code: preprod
+      environment_name: Pre-Production
+      environment_url: https://docs.spacelift.dev/
+      deploy_self_hosted: true
+    secrets:
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+      BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
+      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+
+  # TODO: Enable production deployment after going live with self-hosted docs
+  # deploy-to-prod:
+  #   name: Deploy to production
+  #   uses: ./.github/workflows/deploy-to-environment.yaml
+  #   needs: create-new-release
+  #   with:
+  #     environment_code: prod
+  #     environment_name: Production
+  #     environment_url: https://docs.spacelift.io/
+  #   secrets:
+  #     AWS_REGION: ${{ secrets.AWS_REGION }}
+  #     AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #     BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
+  #     CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+# Make sure that we don't try to deploy from both this workflow and the self-hosted-release workflow
+concurrency:
+  group: "deployment"
+
 jobs:
   deploy-to-preprod:
     name: Deploy to pre-production


### PR DESCRIPTION
# Description of the change

This new workflow allows us to tag the repo with a tag in the format `self-hosted-vx.y.z` to automatically publish a new version of the self-hosted documentation. This will run Mike, push the changes to the `self-hosted-releases` branch, and then trigger deployments.

For now I've left the production deploy commented out because I don't want to accidentally deploy to prod until we're happy.

I've also added concurrency groups to both the self-hosted release workflow and the main deployment workflow to avoid a situation where both attempt to deploy changes at the same time.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
<!-- TODO: re-add the preview once we setup Render again -->
<!-- - [ ] The preview looks fine. -->
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
