### PR TITLE
GitLab: fix link pointing to stack creation description

### DIFF
--- a/docs/integrations/source-control/gitlab.md
+++ b/docs/integrations/source-control/gitlab.md
@@ -42,7 +42,7 @@ If your Spacelift account is integrated with GitLab, the stack or module creatio
 
 ![](../../assets/screenshots/Screen Shot 2022-05-18 at 1.19.49 PM.png)
 
-The rest of the process is exactly the same as with [creating a GitHub-backed stack](../../concepts/stack/README.md#integrate-vcs) or module, so we won't be going into further details. An important thing though is that for every GitLab project that's being used by a Spacelift project (stack or module), you will need to set up a webhook to notify Spacelift about the project changes. That's where you will use the webhooks data from the previous step - the URL and webhook secret.
+The rest of the process is exactly the same as with [creating a GitHub-backed stack](../../concepts/stack/creating-a-stack.md#integrate-vcs) or module, so we won't be going into further details. An important thing though is that for every GitLab project that's being used by a Spacelift project (stack or module), you will need to set up a webhook to notify Spacelift about the project changes. That's where you will use the webhooks data from the previous step - the URL and webhook secret.
 
 Spacelift is interested in pushes, tags and merge requests, so make sure you add triggers for all these types of events:
 


### PR DESCRIPTION
# Description of the change

GitLab: fix link pointing to stack creation description

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
<!-- TODO: re-add the preview once we setup Render again -->
<!-- - [ ] The preview looks fine. -->
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
