### PR TITLE
Fix the preview commands

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,15 +1,15 @@
 {
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "type": "shell",
-            "label": "Start Mkdocs container (arm64)",
-            "command": "docker run --rm -it -p 8000:8000 -v ${workspaceFolder}:/docs ghcr.io/afritzler/mkdocs-material",
-        },
-        {
-            "type": "shell",
-            "label": "Start Mkdocs container (amd64)",
-            "command": "docker run --rm -it -p 8000:8000 -v ${workspaceFolder}:/docs squidfunk/mkdocs-material",
-        }
-    ]
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "shell",
+      "label": "Start Mkdocs container",
+      "command": "docker run --pull always --rm -it -p 8000:8000 -v ${PWD}:/docs python:$(cat .python-version | tr -d '\n')-alpine sh -c \"apk add git && pip install mkdocs && pip install -r /docs/requirements.txt && cd /docs && mkdocs serve -a '0.0.0.0:8000'\""
+    },
+    {
+      "type": "shell",
+      "label": "Start Mkdocs (self-hosted) container",
+      "command": "git fetch origin self-hosted-releases && docker run --pull always --rm -it -p 8000:8000 -v ${PWD}:/docs python:$(cat .python-version | tr -d '\n')-alpine sh -c \"apk add git && git config --global --add safe.directory /docs && pip install mkdocs && pip install -r /docs/requirements.txt && cd /docs && mike serve --branch self-hosted-releases -a '0.0.0.0:8000'\""
+    }
+  ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,14 +31,10 @@ To tweak the look and feel of the user documentation, you can:
 
 ## Previewing Changes
 
-You can preview changes locally by running MkDocs in a Docker container:
+You can preview changes locally by running `mkdocs serve`. You can use the following command to run this inside a Docker container:
 
 ```shell
-# Intel/AMD CPU
-docker run --pull always --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material:$(awk -F '==' '/mkdocs-material/{print $NF}' requirements.txt)
-
-# Arm CPU
-docker run --pull always --rm -it -p 8000:8000 -v ${PWD}:/docs ghcr.io/afritzler/mkdocs-material:$(awk -F '==' '/mkdocs-material/{print $NF}' requirements.txt)
+docker run --pull always --rm -it -p 8000:8000 -v ${PWD}:/docs python:$(cat .python-version | tr -d '\n')-alpine sh -c "apk add git && pip install mkdocs && pip install -r /docs/requirements.txt && cd /docs && mkdocs serve -a '0.0.0.0:8000'"
 ```
 
 > 💡 These commands are [set up](.vscode/tasks.json) as [VS Code tasks](https://code.visualstudio.com/docs/editor/tasks), so you can just run them from the VS Code command palette. Or even better: download the [Task Explorer](https://marketplace.visualstudio.com/items?itemName=spmeesseman.vscode-taskexplorer) extension and you can run them from the sidebar.
@@ -141,10 +137,22 @@ stack:
 
 When you open a PR against the repo, a Render preview will automatically be generated. This preview also includes the latest version of the self-hosted docs. This allows you to preview any changes you are making to the self-hosted docs.
 
-If you would like to preview the self-hosted site locally, you can use the following command:
+If you would like to preview the self-hosted site locally, first fetch the `self-hosted-releases` branch, which Mike uses to serve its content:
+
+```shell
+git fetch origin self-hosted-releases
+```
+
+Next, use `mike serve` to preview the site:
 
 ```shell
 mike serve --branch self-hosted-releases
+```
+
+Or via Docker:
+
+```shell
+docker run --pull always --rm -it -p 8000:8000 -v ${PWD}:/docs python:$(cat .python-version | tr -d '\n')-alpine sh -c "apk add git && git config --global --add safe.directory /docs && pip install mkdocs && pip install -r /docs/requirements.txt && cd /docs && mike serve --branch self-hosted-releases -a '0.0.0.0:8000'"
 ```
 
 ## Submitting Changes


### PR DESCRIPTION
# Description of the change

The preview commands were broken because of the new mkdocs plugins that have been added. I've updated the commands to just use the `python` Docker image. This means we can install the correct dependencies via the requirements.txt file, although it does make the commands pretty verbose.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
<!-- TODO: re-add the preview once we setup Render again -->
<!-- - [ ] The preview looks fine. -->
- [ ] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
