### PR TITLE
Fix the link to the install guide

### DIFF
--- a/docs/self-hosted.md
+++ b/docs/self-hosted.md
@@ -8,7 +8,7 @@ Alongside our SaaS product, we also provide a self-hosted version of Spacelift t
 
 ## Documentation
 
-You can find the documentation for the latest version of self-hosted [here](./self-hosted/latest/). You can find our installation guide [here](./self-hosted/latest/product/administration/install/).
+You can find the documentation for the latest version of self-hosted [here](./self-hosted/latest/). You can find our installation guide [here](./self-hosted/latest/product/administration/install).
 
 ## Differences between SaaS and Self-Hosted
 


### PR DESCRIPTION
# Description of the change

The link to the self-hosted install guide is broken because of the way our Lambda that adjusts URLs works. It needs the trailing slash removed to work.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
