### PR TITLE
add panel to say Login Policy is not on Free Tier

### DIFF
--- a/docs/concepts/policy/login-policy.md
+++ b/docs/concepts/policy/login-policy.md
@@ -4,6 +4,9 @@
 
 Login policies can allow users to log in to the account, and optionally give them admin privileges, too. Unlike all other policy types, login policies are global and can't be attached to individual stacks. They take effect immediately once they're created and affect all future login attempts.
 
+!!! info
+    Login Policies are only evaluated when using the Cloud or Enterprise Tier.
+
 !!! warning
     Login policies don't affect GitHub organization or [SSO](../../integrations/single-sign-on/README.md) admins and private account owners who always get admin access to their respective Spacelift accounts. This is to avoid a situation where a bad login policy locks out everyone from the account.
 

--- a/docs/concepts/policy/login-policy.md
+++ b/docs/concepts/policy/login-policy.md
@@ -5,7 +5,7 @@
 Login policies can allow users to log in to the account, and optionally give them admin privileges, too. Unlike all other policy types, login policies are global and can't be attached to individual stacks. They take effect immediately once they're created and affect all future login attempts.
 
 !!! info
-    Login Policies are only evaluated when using the Cloud or Enterprise Tier.
+    Login policies are only evaluated for the [Cloud or Enterprise plan](https://spacelift.io/pricing).
 
 !!! warning
     Login policies don't affect GitHub organization or [SSO](../../integrations/single-sign-on/README.md) admins and private account owners who always get admin access to their respective Spacelift accounts. This is to avoid a situation where a bad login policy locks out everyone from the account.


### PR DESCRIPTION
# Description of the change

Added an info panel to let the reader know that the login policy is not evaluated on the free tier. 

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
