### PR TITLE
Enable self-hosted docs in live site

### DIFF
--- a/.github/workflows/self-hosted-release.yaml
+++ b/.github/workflows/self-hosted-release.yaml
@@ -86,17 +86,17 @@ jobs:
       BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
       CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
 
-  # TODO: Enable production deployment after going live with self-hosted docs
-  # deploy-to-prod:
-  #   name: Deploy to production
-  #   uses: ./.github/workflows/deploy-to-environment.yaml
-  #   needs: create-new-release
-  #   with:
-  #     environment_code: prod
-  #     environment_name: Production
-  #     environment_url: https://docs.spacelift.io/
-  #   secrets:
-  #     AWS_REGION: ${{ secrets.AWS_REGION }}
-  #     AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-  #     BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
-  #     CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+  deploy-to-prod:
+    name: Deploy to production
+    uses: ./.github/workflows/deploy-to-environment.yaml
+    needs: create-new-release
+    with:
+      environment_code: prod
+      environment_name: Production
+      environment_url: https://docs.spacelift.io/
+      deploy_self_hosted: true
+    secrets:
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+      BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
+      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -33,6 +33,7 @@ jobs:
       environment_code: prod
       environment_name: Production
       environment_url: https://docs.spacelift.io/
+      deploy_self_hosted: true
     secrets:
       # KLUDGE: We are not actually passing the secrets here.
       # What we’re really doing is passing the key to the secret that we want the reusable workflow to use.

--- a/nav.yaml
+++ b/nav.yaml
@@ -152,3 +152,4 @@ nav:
       - legal/cookie-policy.md
       - Archive:
           - legal/archive/terms.md
+  - 🏰 Self-Hosted: self-hosted.md


### PR DESCRIPTION
# Description of the change

- Enabling deployment of the self-hosted docs to live.
- Adding a link to the self-hosted docs to the navigation.
- Updating the self-hosted release workflow to deploy to production as well as preprod.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [ ] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [ ] The preview looks fine.
- [ ] The tests pass.
- [ ] The commit history is clean and meaningful.
- [ ] The pull request is opened against the `main` branch.
- [ ] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
