### PR TITLE
Mention support email in v0.0.7 docs

### DIFF
--- a/v0.0.7/product/support/index.html
+++ b/v0.0.7/product/support/index.html
@@ -3265,7 +3265,7 @@
 </li>
 </ul>
 <h2 id="contacting-support">Contacting Support<a class="headerlink" href="#contacting-support" title="Anchor link to this section">»</a></h2>
-<p>For technical questions related to the Spacelift product, open a support ticket in the shared Slack channel (preferred, when available).</p>
+<p>For technical questions related to the Spacelift product, open a support ticket in the shared Slack channel (preferred, when available), or email support@spacelift.io if using Slack is not possible.</p>
 <p>Questions related to billing, purchasing, or subscriptions should be sent to <a href="mailto:ar@spacelift.io">ar@spacelift.io</a>.</p>
 <h2 id="support-sla">Support SLA<a class="headerlink" href="#support-sla" title="Anchor link to this section">»</a></h2>
 <p>The SLA times listed below are the timeframes in which you can expect the first response. Spacelift will make the best effort to resolve any issues to your satisfaction as quickly as possible. However, the SLA times are not to be considered as an expected time-to-resolution.</p>


### PR DESCRIPTION
# Description of the change

Updating the v0.0.7 snapshot of the self-hosted docs to mention the support email.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [ ] The preview looks fine.
- [ ] The tests pass.
- [x] The commit history is clean and meaningful.
- [ ] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
