### PR TITLE
Build separate preprod/prod copies of self-hosted

### DIFF
--- a/.github/workflows/self-hosted-release.yaml
+++ b/.github/workflows/self-hosted-release.yaml
@@ -54,49 +54,68 @@ jobs:
         # This step could fail if the branch doesn't already exist, but that's fine because Mike will create it.
         continue-on-error: true
         run: |
-          git fetch origin ${{ env.release_branch_name }} --depth=1
+          git fetch origin "${{ env.release_branch_name }}-prod" --depth=1
+          git fetch origin "${{ env.release_branch_name }}-preprod" --depth=1
 
-      - name: "Create release"
+      - name: "Create prod release"
         run: |
           # Configure Git to allow Mike to commit to the release branch
           git config user.name self-hosted-releases
           git config user.email self-hosted-releases@spacelift.io
 
           # Create release using Mike
-          mike deploy -u --branch ${{ env.release_branch_name }} ${VERSION} latest
+          mike deploy -u --branch "${{ env.release_branch_name }}-prod" ${VERSION} latest
         env:
           NAV_FILE: "./nav.self-hosted.yaml"
           SPACELIFT_DISTRIBUTION: "SELF_HOSTED"
+          DOC_ENV: prod
+          WP_OPTIONS_API_URL: ${{ vars.WP_OPTIONS_API_URL }}
 
-      - name: "Push branch"
-        run: "git push origin self-hosted-releases:refs/heads/self-hosted-releases"
+      - name: "Create preprod release"
+        run: |
+          # Configure Git to allow Mike to commit to the release branch
+          git config user.name self-hosted-releases
+          git config user.email self-hosted-releases@spacelift.io
 
-  deploy-to-preprod:
-    name: Deploy to pre-production
-    uses: ./.github/workflows/deploy-to-environment.yaml
-    needs: create-new-release
-    with:
-      environment_code: preprod
-      environment_name: Pre-Production
-      environment_url: https://docs.spacelift.dev/
-      deploy_self_hosted: true
-    secrets:
-      AWS_REGION: ${{ secrets.AWS_REGION }}
-      AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-      BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
-      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+          # Create release using Mike
+          mike deploy -u --branch "${{ env.release_branch_name }}-preprod" ${VERSION} latest
+        env:
+          NAV_FILE: "./nav.self-hosted.yaml"
+          SPACELIFT_DISTRIBUTION: "SELF_HOSTED"
+          DOC_ENV: preprod
+          WP_OPTIONS_API_URL: ${{ vars.WP_OPTIONS_API_URL }}
 
-  deploy-to-prod:
-    name: Deploy to production
-    uses: ./.github/workflows/deploy-to-environment.yaml
-    needs: create-new-release
-    with:
-      environment_code: prod
-      environment_name: Production
-      environment_url: https://docs.spacelift.io/
-      deploy_self_hosted: true
-    secrets:
-      AWS_REGION: ${{ secrets.AWS_REGION }}
-      AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-      BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
-      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+      - name: "Push branches"
+        run: |
+          git push origin self-hosted-releases-prod:refs/heads/self-hosted-releases-prod
+          git push origin self-hosted-releases-preprod:refs/heads/self-hosted-releases-preprod
+
+  # deploy-to-preprod:
+  #   name: Deploy to pre-production
+  #   uses: ./.github/workflows/deploy-to-environment.yaml
+  #   needs: create-new-release
+  #   with:
+  #     environment_code: preprod
+  #     environment_name: Pre-Production
+  #     environment_url: https://docs.spacelift.dev/
+  #     deploy_self_hosted: true
+  #   secrets:
+  #     AWS_REGION: ${{ secrets.AWS_REGION }}
+  #     AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #     BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
+  #     CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+
+  # deploy-to-prod:
+  #   name: Deploy to production
+  #   uses: ./.github/workflows/deploy-to-environment.yaml
+  #   needs: create-new-release
+  #   with:
+  #     environment_code: prod
+  #     environment_name: Production
+  #     environment_url: https://docs.spacelift.io/
+  #     deploy_self_hosted: true
+  #   secrets:
+  #     AWS_REGION: ${{ secrets.AWS_REGION }}
+  #     AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #     BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
+  #     CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}

--- a/scripts/render-build.sh
+++ b/scripts/render-build.sh
@@ -7,4 +7,4 @@ mkdir -p site/self-hosted
 mkdocs build
 
 # Build the self-hosting version of the site
-NAV_FILE=./nav.self-hosted.yaml SPACELIFT_DISTRIBUTION=SELF_HOSTED mkdocs build -d site/self-hosted/latest
+NAV_FILE=./nav.self-hosted.yaml SPACELIFT_DISTRIBUTION=SELF_HOSTED DOC_ENV=preprod mkdocs build -d site/self-hosted/latest


### PR DESCRIPTION
# Description of the change

The current version of the self-hosted docs build wasn't specifying the `DOC_ENV` flag. This meant that we were using the development configuration for things like analytics.

To solve what I've done is created two Mike builds - one for preprod and another for prod. They publish to two separate branches: `self-hosted-releases-preprod` and `self-hosted-releases-prod`. I haven't updated the main workflow yet to use those branches, and I've also disabled the deploy on the self-hosted-release workflow because we need the branches to be created before we can use them. I'll update the workflows in a separate PR.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
