### PR TITLE
Deploy self-hosted docs from correct branch

### DIFF
--- a/.github/workflows/deploy-to-environment.yaml
+++ b/.github/workflows/deploy-to-environment.yaml
@@ -37,6 +37,7 @@ jobs:
     env:
       DOC_ENV: ${{ inputs.environment_code }}
       WP_OPTIONS_API_URL: ${{ vars.WP_OPTIONS_API_URL }}
+      RELEASE_BRANCH_NAME: ${{ inputs.environment_code == 'prod' && 'self-hosted-releases-prod' || 'self-hosted-releases-preprod' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -45,8 +46,8 @@ jobs:
         if: ${{ inputs.deploy_self_hosted }}
         uses: actions/checkout@v3
         with:
-          ref: self-hosted-releases
-          path: self-hosted-releases
+          ref: ${{ env.RELEASE_BRANCH_NAME }}
+          path: ${{ env.RELEASE_BRANCH_NAME }}
 
       - name: Set Python up
         uses: actions/setup-python@v4
@@ -63,9 +64,9 @@ jobs:
         if: ${{ inputs.deploy_self_hosted }}
         run: |
           mkdir -p site/self-hosted
-          cp -r self-hosted-releases/latest site/self-hosted
-          cp -r self-hosted-releases/v* site/self-hosted
-          cp self-hosted-releases/versions.json site/self-hosted
+          cp -r ${{ env.RELEASE_BRANCH_NAME }}/latest site/self-hosted
+          cp -r ${{ env.RELEASE_BRANCH_NAME }}/v* site/self-hosted
+          cp ${{ env.RELEASE_BRANCH_NAME }}/versions.json site/self-hosted
 
       - name: Transform the URLs
         run: python ./scripts/transform_urls.py

--- a/.github/workflows/self-hosted-release.yaml
+++ b/.github/workflows/self-hosted-release.yaml
@@ -90,32 +90,32 @@ jobs:
           git push origin self-hosted-releases-prod:refs/heads/self-hosted-releases-prod
           git push origin self-hosted-releases-preprod:refs/heads/self-hosted-releases-preprod
 
-  # deploy-to-preprod:
-  #   name: Deploy to pre-production
-  #   uses: ./.github/workflows/deploy-to-environment.yaml
-  #   needs: create-new-release
-  #   with:
-  #     environment_code: preprod
-  #     environment_name: Pre-Production
-  #     environment_url: https://docs.spacelift.dev/
-  #     deploy_self_hosted: true
-  #   secrets:
-  #     AWS_REGION: ${{ secrets.AWS_REGION }}
-  #     AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-  #     BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
-  #     CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+  deploy-to-preprod:
+    name: Deploy to pre-production
+    uses: ./.github/workflows/deploy-to-environment.yaml
+    needs: create-new-release
+    with:
+      environment_code: preprod
+      environment_name: Pre-Production
+      environment_url: https://docs.spacelift.dev/
+      deploy_self_hosted: true
+    secrets:
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+      BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
+      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
 
-  # deploy-to-prod:
-  #   name: Deploy to production
-  #   uses: ./.github/workflows/deploy-to-environment.yaml
-  #   needs: create-new-release
-  #   with:
-  #     environment_code: prod
-  #     environment_name: Production
-  #     environment_url: https://docs.spacelift.io/
-  #     deploy_self_hosted: true
-  #   secrets:
-  #     AWS_REGION: ${{ secrets.AWS_REGION }}
-  #     AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-  #     BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
-  #     CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+  deploy-to-prod:
+    name: Deploy to production
+    uses: ./.github/workflows/deploy-to-environment.yaml
+    needs: create-new-release
+    with:
+      environment_code: prod
+      environment_name: Production
+      environment_url: https://docs.spacelift.io/
+      deploy_self_hosted: true
+    secrets:
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+      BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
+      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}


### PR DESCRIPTION
# Description of the change

- Updated the deployment workflow to get the self-hosted docs from the correct branch depending on the environment being deployed.
- Updated the self-hosted release process to trigger a deploy again.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
