### PR TITLE
Remove self-hosted.md from self-hosted docs

### DIFF
--- a/.github/workflows/self-hosted-release.yaml
+++ b/.github/workflows/self-hosted-release.yaml
@@ -42,6 +42,13 @@ jobs:
         with:
           token: ${{ steps.generate_token.outputs.token }}
 
+      # We need to remove the self-hosted.md page because it only makes sense in the SaaS docs.
+      # It's the page that provides general info about self-hosted, and links to the self-hosted
+      # section of the site. It's not linked in the nav, but this just makes sure that no-one
+      # accesses it by accident and gets confused.
+      - name: Remove self-hosted page
+        run: rm docs/self-hosted.md
+
       - name: Set Python up
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
# Description of the change

It means that if someone goes to https://docs.spacelift.io/self-hosted/latest/self-hosted they'll get a 404 instead of getting a page with broken links.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
