### PR TITLE
Add push policy redirect

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -78,3 +78,6 @@ plugins:
       deploy_prefix: ""
       canonical_version: "latest"
       version_selector: true
+  - redirects:
+      redirect_maps:
+        "concepts/policy/git-push-policy.md": "concepts/policy/push-policy/README.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs-material==8.5.11
 mkdocs-macros-plugin==1.0.1
 mike @ git+https://github.com/jimporter/mike.git
+mkdocs-redirects


### PR DESCRIPTION
# Description of the change

It looks like during adding [external dependencies docs](https://github.com/spacelift-io/user-documentation/commit/8d38961a646053f566fcaeea7ebd17b033b66e75#diff-8bd4b3e7221bce03a74d78a5a2ba5c43327621cf8ddc583c111a15ed619b24ac) we moved `git-push-policies` to just `push-policies` which is fine, but we should add some redirects just in case we linked to git-push-policies page somewhere before. 

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- [ ] You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
