### PR TITLE
Add stack_destructor_resource to destroy_hooks

### DIFF
--- a/docs/concepts/stack/stack-dependencies.md
+++ b/docs/concepts/stack/stack-dependencies.md
@@ -177,7 +177,7 @@ A stack cannot be deleted if it has upstream or downstream dependencies. If you 
 
 As [mentioned earlier](#goals), Stack Dependencies do not aim to handle the lifecycle of the stacks.
 
-Ordering the creation and deletion of stacks in a specific order is not impossible though. If you manage your Spacelift stacks with the [Spacelift Terraform Provider](../../vendors/terraform/terraform-provider.md), you can easily do it by setting `spacelift_stack_destructor` resources and setting the [`depends_on`](https://developer.hashicorp.com/terraform/language/meta-arguments/depends_on) Terraform attribute on them.
+Ordering the creation and deletion of stacks in a specific order is not impossible though. If you manage your Spacelift stacks with the [Spacelift Terraform Provider](../../vendors/terraform/terraform-provider.md), you can easily do it by setting [`spacelift_stack_destructor`](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/stack_destructor) resources and setting the [`depends_on`](https://developer.hashicorp.com/terraform/language/meta-arguments/depends_on) Terraform attribute on them.
 
 Here is a simple example of creating a dependency between two stacks, immediately triggering a run on the parent stack (which cascades to the child stack) and setting up a destructor for them. By setting up a destructor resource with the proper `depends_on` attribute, it ensures that the deletion of the stacks will happen in the proper order. First child, then parent. This is also an easy way to create short-lived environments.
 

--- a/docs/concepts/stack/stack-settings.md
+++ b/docs/concepts/stack/stack-settings.md
@@ -39,7 +39,9 @@ Spacelift workflow can be customized by adding extra commands to be executed bef
 - [Initialization](../run/README.md#initializing) (`before_init` and `after_init`, respectively)
 - [Planning](../run/proposed.md#planning) (`before_plan` and `after_plan`, respectively)
 - [Applying](../run/tracked.md#applying) (`before_apply` and `after_apply`, respectively)
-- [Destroying](../run/test-case.md) (`before_destroy` and `after_destroy`, respectively)
+- Destroying (`before_destroy` and `after_destroy`, respectively)
+    - [used during module test cases](../run/test-case.md)
+    - used by stacks during destruction that have corresponding [stack_destructor_resource](../stack/stack-dependencies.md#ordered-stack-creation-and-deletion)
 - [Performing](../run/task.md#performing-a-task) (`before_perform` and `after_perform`, respectively)
 
 You can also set up hooks (`after_run`) that will execute after each actively processed run, regardless of its outcome. These hooks will execute as part of the last "active" state of the run and will have access to an environment variable called `TF_VAR_spacelift_final_run_state` indicating the final state of the run.


### PR DESCRIPTION
# Description of the change

Add `stack_destructor` resource information to `*_destroy` hooks.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
