### PR TITLE
Added notice to tf+tg page to notify users of the new terragrunt beta

### DIFF
--- a/docs/vendors/terraform/terragrunt.md
+++ b/docs/vendors/terraform/terragrunt.md
@@ -1,5 +1,8 @@
 # Terragrunt
 
+!!! info
+    We have recently released a new Terragrunt native platform in Spacelift and it is currently in **beta**. You can find documentation on this [here](../terragrunt/README.md)
+
 ## Using Terragrunt
 
 Whether a Terraform stack is using Terragrunt or not is controlled by the presence of `terragrunt` label on the stack:


### PR DESCRIPTION
# Description of the change

This adds a notice to the current terraform+terragrunt docs page to point to the new beta page.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
