### PR TITLE
Mention upgrade CF workers template when upgrading

### DIFF
--- a/docs/product/administration/install.md
+++ b/docs/product/administration/install.md
@@ -323,7 +323,7 @@ To upgrade to the latest version of self-hosting, follow these steps:
 
 1. Make sure your config.json file is fully configured to match your existing installation. Ideally you should use the config file from your previous installation.
 2. Run `./install.sh`.
-3. Restart any workers connected to your Spacelift installation to make sure they're running the latest version.
+3. Deploy the latest version of the [CloudFormation worker pool template](../../concepts/worker-pools.md#cloudformation-template), and restart any workers connected to your Spacelift installation to make sure they're running the latest version.
 
 ## Uninstalling
 


### PR DESCRIPTION
# Description of the change

Updated the Self-Hosted upgrade notes to also mention deploying the latest version of the Cloudformation worker pool template. While this isn't strictly necessary, it's possible we may have included fixes to the worker pool template as part of a release.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
