### PR TITLE
Updated references for the Helm Chart repo to new URL and repo name

### DIFF
--- a/docs/concepts/worker-pools.md
+++ b/docs/concepts/worker-pools.md
@@ -86,7 +86,7 @@ For AWS, Azure and GCP users we've prepared an easy way to run Spacelift worker 
 - Azure: [terraform-azure-spacelift-workerpool](https://github.com/spacelift-io/terraform-azure-spacelift-workerpool){: rel="nofollow"}.
 - GCP: [terraform-google-spacelift-workerpool](https://github.com/spacelift-io/terraform-google-spacelift-workerpool){: rel="nofollow"}.
 
-In addition, the [spacelift-workerpool-k8s](https://github.com/spacelift-io/spacelift-workerpool-k8s){: rel="nofollow"} repository contains a Helm chart for deploying workers to Kubernetes.
+In addition, the [spacelift-helm-charts](https://github.com/spacelift-io/spacelift-helm-charts){: rel="nofollow"} repository contains a Helm chart for deploying workers to Kubernetes.
 
 !!! tip
     Since the Launcher is getting downloaded during the instance startup, it is recommended to recycle the worker pool every once in a while to ensure that it is up to date. You don't want to miss out on the latest features and bug fixes! You can do this by draining all the workers one-by-one in the UI, then terminating the instances in your cloud provider.
@@ -332,7 +332,7 @@ Our public [AWS](https://github.com/spacelift-io/terraform-aws-spacelift-workerp
 
 ### Running Workers in Kubernetes
 
-You can run Spacelift workers for your self-hosted instance in Kubernetes, for example using our [Helm chart](https://github.com/spacelift-io/spacelift-workerpool-k8s). The main thing to be aware of is that the launcher is designed to work with a specific version of Spacelift, so it's important to use the correct container image for your Spacelift install.
+You can run Spacelift workers for your self-hosted instance in Kubernetes, for example using our [Helm chart](https://github.com/spacelift-io/spacelift-helm-charts). The main thing to be aware of is that the launcher is designed to work with a specific version of Spacelift, so it's important to use the correct container image for your Spacelift install.
 
 #### Finding the Launcher Image
 

--- a/docs/vendors/kubernetes/helm.md
+++ b/docs/vendors/kubernetes/helm.md
@@ -7,7 +7,7 @@ Please note, the following caveats apply:
 - Using `helm template` means that you are not using the full Helm workflow, which may cause limitations or prevent certain Charts from working.
 - You need to use a custom [Spacelift worker image](../../integrations/docker.md#customizing-the-runner-image) that has Helm installed, or alternatively you can install Helm using a _before init_ hook.
 
-The rest of this page will go through an example of deploying the [Spacelift Workerpool Helm Chart](https://github.com/spacelift-io/spacelift-workerpool-k8s) using the Kubernetes integration. See [here](https://github.com/spacelift-io/kubernetes-helm-example) for an example repository.
+The rest of this page will go through an example of deploying the [Spacelift Workerpool Helm Chart](https://github.com/spacelift-io/spacelift-helm-charts) using the Kubernetes integration. See [here](https://github.com/spacelift-io/kubernetes-helm-example) for an example repository.
 
 ## Prerequisites
 


### PR DESCRIPTION
# Description of the change

I've updated the references to the Helm Chart repository since the repository name is changed after publishing the VCS Agent Helm chart in the same repository.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
