### PR TITLE
added new environment variable documentation for terragrunt backends

### DIFF
--- a/docs/vendors/terragrunt/reference.md
+++ b/docs/vendors/terragrunt/reference.md
@@ -20,5 +20,6 @@ In Terragrunt stacks you can use environment variables to add options to the com
 
 There is an environment variable for each phase of the run:
 
+- `TG_CLI_ARGS_init` - Allows you to add options sent to the Terragrunt application during the initalization phase
 - `TG_CLI_ARGS_plan` - Allows you to add options sent to the Terragrunt application during the planning phase
 - `TG_CLI_ARGS_apply` - Allows you to add options sent to the Terragrunt application during the applying phase


### PR DESCRIPTION
# Description of the change

A new environment variable (`TG_CLI_ARGS_init`) is now supported to allow for setting env vars during the init phase too.


## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
