### PR TITLE
Add documentation on enabling git checkout support

### DIFF
--- a/docs/integrations/source-control/github.md
+++ b/docs/integrations/source-control/github.md
@@ -325,6 +325,13 @@ If a GitHub repository is renamed, we update its name in all the [stacks](../../
 
 You can use the [Setup Spacectl](https://github.com/marketplace/actions/setup-spacectl){: rel="nofollow"} GitHub Action to install our [spacectl](https://github.com/spacelift-io/spacectl){: rel="nofollow"} CLI tool to easily interact with Spacelift.
 
+## Git checkout support
+
+By default Spacelift uses the GitHub API to download a tarball containing the source code for your stack or module. We are introducing experimental support for downloading the code using a standard Git checkout. If you would like to enable this for your stacks/modules, there are currently two options available:
+
+1. Add a label called `feature:use_git_checkout` to each stack or module that you want to use Git checkout on. This allows you to test the new support without switching over all your stacks at once.
+2. Contact our support team and ask us to enable the feature for all stacks/modules in your account.
+
 ## Unlinking GitHub and Spacelift
 
 === "Uninstalling the Marketplace application"


### PR DESCRIPTION
# Description of the change

Documenting how to enable git checkout support for an individual stack/module. At the moment the stack label is only supported for GitHub (both managed and custom App), so I've added it to the GitHub section of the docs.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
