### PR TITLE
Fix canonical links for self-hosted docs

### DIFF
--- a/.github/workflows/self-hosted-release.yaml
+++ b/.github/workflows/self-hosted-release.yaml
@@ -77,6 +77,7 @@ jobs:
           DOC_ENV: prod
           LOGO: "assets/images/logo-selfhosted.svg"
           WP_OPTIONS_API_URL: ${{ vars.WP_OPTIONS_API_URL }}
+          SITE_NAME: "https://docs.spacelift.io/self-hosted"
 
       - name: "Create preprod release"
         run: |
@@ -91,6 +92,7 @@ jobs:
           SPACELIFT_DISTRIBUTION: "SELF_HOSTED"
           DOC_ENV: preprod
           WP_OPTIONS_API_URL: ${{ vars.WP_OPTIONS_API_URL }}
+          SITE_NAME: "https://docs.spacelift.io/self-hosted"
 
       - name: "Push branches"
         run: |

--- a/.github/workflows/self-hosted-release.yaml
+++ b/.github/workflows/self-hosted-release.yaml
@@ -77,7 +77,7 @@ jobs:
           DOC_ENV: prod
           LOGO: "assets/images/logo-selfhosted.svg"
           WP_OPTIONS_API_URL: ${{ vars.WP_OPTIONS_API_URL }}
-          SITE_NAME: "https://docs.spacelift.io/self-hosted"
+          SITE_URL: "https://docs.spacelift.io/self-hosted"
 
       - name: "Create preprod release"
         run: |
@@ -92,7 +92,7 @@ jobs:
           SPACELIFT_DISTRIBUTION: "SELF_HOSTED"
           DOC_ENV: preprod
           WP_OPTIONS_API_URL: ${{ vars.WP_OPTIONS_API_URL }}
-          SITE_NAME: "https://docs.spacelift.io/self-hosted"
+          SITE_URL: "https://docs.spacelift.dev/self-hosted"
 
       - name: "Push branches"
         run: |

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -3,7 +3,7 @@ copyright: © 2022 Spacelift, Inc. All rights reserved
 site_author: Spacelift
 site_description: Collaborative Infrastructure For Modern Software Teams
 site_name: Spacelift Documentation
-site_url: !ENV [SITE_NAME, "https://docs.spacelift.io"]
+site_url: !ENV [SITE_URL, "https://docs.spacelift.io"]
 theme:
   custom_dir: overrides
   favicon: assets/images/favicon.png

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -3,7 +3,7 @@ copyright: © 2022 Spacelift, Inc. All rights reserved
 site_author: Spacelift
 site_description: Collaborative Infrastructure For Modern Software Teams
 site_name: Spacelift Documentation
-site_url: https://docs.spacelift.io
+site_url: !ENV [SITE_NAME, "https://docs.spacelift.io"]
 theme:
   custom_dir: overrides
   favicon: assets/images/favicon.png

--- a/scripts/render-build.sh
+++ b/scripts/render-build.sh
@@ -12,4 +12,4 @@ git checkout docs
 
 # Build the self-hosting version of the site
 SPACELIFT_DISTRIBUTION=SELF_HOSTED ./scripts/remove-files-based-on-distribution.sh
-NAV_FILE=./nav.self-hosted.yaml SPACELIFT_DISTRIBUTION=SELF_HOSTED DOC_ENV=preprod LOGO=assets/images/logo-selfhosted.svg mkdocs build -d site/self-hosted/latest
+NAV_FILE=./nav.self-hosted.yaml SPACELIFT_DISTRIBUTION=SELF_HOSTED DOC_ENV=preprod LOGO=assets/images/logo-selfhosted.svg SITE_URL=https://docs.spacelift.dev/self-hosted mkdocs build -d site/self-hosted/latest


### PR DESCRIPTION
# Description of the change

Fix canonical links for self hosted docs to match URLs

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [ ] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
