### PR TITLE
Fix a few warnings about links to index pages

### DIFF
--- a/docs/concepts/configuration/context.md
+++ b/docs/concepts/configuration/context.md
@@ -57,7 +57,7 @@ This is the only mandatory step in the context creation process; the remaining s
 
 The required _name_ is what you'll see in the context list and in the dropdown when attaching the context to projects. Ensure it's informative enough to immediately convey the purpose of the context, yet short enough to fit neatly in dropdowns without cutting off important information.
 
-The last required field in this step is _space_, allowing you to choose which [space](../spaces/) the context will belong to.
+The last required field in this step is _space_, allowing you to choose which [space](../spaces/README.md) the context will belong to.
 
 The optional _description_ is free-form and supports [Markdown](https://daringfireball.net/projects/markdown/){: rel="nofollow"}. This is an ideal place for a thorough explanation of the context's purpose, perhaps with links or a humorous GIF. In the web GUI, this description appears in several places: on the context list, in the context view, and in the list of attached contexts on the stack view.
 

--- a/docs/concepts/stack/creating-a-stack.md
+++ b/docs/concepts/stack/creating-a-stack.md
@@ -30,7 +30,7 @@ Staring with the most difficult step - naming things. Here's where you give your
 
 You'll be able to change the name and description later, too - with one caveat. Based on the original _name_, Spacelift generates an immutable slug that serves as a unique identifier of this stack. If the name and the slug diverge significantly, things may become confusing.
 
-Here you will be able to choose which [space](../spaces/) your stack belongs to. Initially, you start with a root and a legacy space. The root space is the top-level space of your account, while the legacy space exists for backward compatibility with pre-spaces RBAC.
+Here you will be able to choose which [space](../spaces/README.md) your stack belongs to. Initially, you start with a root and a legacy space. The root space is the top-level space of your account, while the legacy space exists for backward compatibility with pre-spaces RBAC.
 
 Also, this is the opportunity to set a few [labels](stack-settings.md#labels). Labels are useful for searching and grouping things, but also work extremely well with policies.
 

--- a/docs/concepts/stack/stack-dependencies.md
+++ b/docs/concepts/stack/stack-dependencies.md
@@ -79,7 +79,7 @@ output "dummy" {
 
 #### Vendor limitations
 
-[Ansible](../../vendors/ansible/) and [Kubernetes](../../vendors/kubernetes/) does not have the concept of outputs, so you cannot reference the outputs of them. They _can_ be on the receiving end though:
+[Ansible](../../vendors/ansible/README.md) and [Kubernetes](../../vendors/kubernetes/README.md) does not have the concept of outputs, so you cannot reference the outputs of them. They _can_ be on the receiving end though:
 
 ```mermaid
 graph TD;

--- a/docs/vendors/terraform/module-registry.md
+++ b/docs/vendors/terraform/module-registry.md
@@ -221,7 +221,7 @@ Whenever you add a new functionality, you may want to create a feature branch an
 You can also use [Git push policies](../../concepts/policy/push-policy/README.md) to further customize this.
 
 !!! Tip
-    If you would like to manage your Terraform Module versions using git tags, and would like git tag events to push your module to the Spacelift module registry. Please review our [Tag-driven Terraform Module Release Flow](../../concepts/policy/push-policy/#tag-driven-terraform-module-release-flow).
+    If you would like to manage your Terraform Module versions using git tags, and would like git tag events to push your module to the Spacelift module registry. Please review our [Tag-driven Terraform Module Release Flow](../../concepts/policy/push-policy/README.md#tag-driven-terraform-module-release-flow).
 
 !!! info
     If no test cases are present, the version is immediately marked green.


### PR DESCRIPTION
# Description of the change

All relative links in the docs require pointing to real files locally so that MkDocs can verify their existence. There were a few warnings about index links that did not include "README.md" at the end and this PR fixes that.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [ ] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [ ] The preview looks fine.
- [ ] The tests pass.
- [ ] The commit history is clean and meaningful.
- [ ] The pull request is opened against the `main` branch.
- [ ] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
