### PR TITLE
adding reference to format of kubectl timeout variable

### DIFF
--- a/docs/vendors/kubernetes/getting-started.md
+++ b/docs/vendors/kubernetes/getting-started.md
@@ -166,7 +166,7 @@ The following screen highlights the Finished Run and output from a successful de
 ![](../../assets/screenshots/k8s-finished.png)
 
 !!! info "Applying"
-    The default timeout is set to 10 minutes. If a Kubernetes Deployment is expected to take longer, you can customize that using the `KUBECTL_ROLLOUT_TIMEOUT` environment variable.
+    The default timeout is set to 10 minutes (10m). If a Kubernetes Deployment is expected to take longer, you can customize that using the `KUBECTL_ROLLOUT_TIMEOUT` environment variable.
 
     Review the [documentation](../../concepts/configuration/environment.md) to find out more about Spacelift environment variables..
 


### PR DESCRIPTION
# Description of the change

<!-- Please describe the changes that are being added by this PR -->

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
