### PR TITLE
Added warnings to the provider registry docs

### DIFF
--- a/docs/vendors/terraform/provider-registry.md
+++ b/docs/vendors/terraform/provider-registry.md
@@ -38,6 +38,9 @@ resource "spacelift_terraform_provider" "provider" {
 }
 ```
 
+!!! warning
+    The type attribute in the `spacelift_terraform_provider` resource is actually referring to the unique name for the provider within Spacelift account. It must consist of lowercase letters only.
+
 It is possible to mark the provider as public, which will make it available to everyone. This is generally not recommended, as it will make it easy for others to use your provider without your knowledge. At the same time, this is the only way of sharing a provider between Spacelift accounts. If you're doing that, make sure there is nothing sensitive in your provider. In order to mark the provider as public, you need to set its [`public`](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/terraform_provider#public){: rel="nofollow"} attribute to `true`.
 
 #### Use the API
@@ -239,11 +242,17 @@ If everything is fine, pushing a tag like `v0.1.0` should create a new **draft**
 spacectl provider list-versions --type=$YOUR_PROVIDER_TYPE
 ```
 
+!!! warning
+    The type parameter in the `spacectl provider list-versions` command is actually referring to the unique name for the provider within Spacelift account. It must consist of lowercase letters only.
+
 Note the version status. Versions start their life as drafts, and you can publish them by grabbing their ID (first column) and using `spacectl`:
 
 ```bash
 spacectl provider publish-version --version=$YOUR_VERSION_ID
 ```
+
+!!! warning
+    The version parameter in the `spacectl provider publish-versions` command is actually referring to the unique ID for the provider version within Spacelift account.
 
 Once published, your version is ready to use. See the next section for more information.
 

--- a/docs/vendors/terraform/provider-registry.md
+++ b/docs/vendors/terraform/provider-registry.md
@@ -39,7 +39,7 @@ resource "spacelift_terraform_provider" "provider" {
 ```
 
 !!! warning
-    The type attribute in the `spacelift_terraform_provider` resource is actually referring to the unique name for the provider within Spacelift account. It must consist of lowercase letters only.
+    The `type` attribute in the `spacelift_terraform_provider` resource refers to the unique name of the provider within Spacelift account. It must consist of lowercase letters only.
 
 It is possible to mark the provider as public, which will make it available to everyone. This is generally not recommended, as it will make it easy for others to use your provider without your knowledge. At the same time, this is the only way of sharing a provider between Spacelift accounts. If you're doing that, make sure there is nothing sensitive in your provider. In order to mark the provider as public, you need to set its [`public`](https://registry.terraform.io/providers/spacelift-io/spacelift/latest/docs/resources/terraform_provider#public){: rel="nofollow"} attribute to `true`.
 
@@ -243,7 +243,7 @@ spacectl provider list-versions --type=$YOUR_PROVIDER_TYPE
 ```
 
 !!! warning
-    The type parameter in the `spacectl provider list-versions` command is actually referring to the unique name for the provider within Spacelift account. It must consist of lowercase letters only.
+    The `type` parameter in the `spacectl provider list-versions` command refers to the unique name of the provider within Spacelift account. It must consist of lowercase letters only.
 
 Note the version status. Versions start their life as drafts, and you can publish them by grabbing their ID (first column) and using `spacectl`:
 
@@ -252,7 +252,7 @@ spacectl provider publish-version --version=$YOUR_VERSION_ID
 ```
 
 !!! warning
-    The version parameter in the `spacectl provider publish-versions` command is actually referring to the unique ID for the provider version within Spacelift account.
+    The `version` parameter in the `spacectl provider publish-versions` command refers to the unique ID of the provider version within Spacelift account.
 
 Once published, your version is ready to use. See the next section for more information.
 


### PR DESCRIPTION
# Description of the change

Added warning blocks to the Provider Registry documentation about the `type` and `version ID` attributes.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
