### PR TITLE
Clarify the motivation for using blueprints

### DIFF
--- a/docs/concepts/blueprint/README.md
+++ b/docs/concepts/blueprint/README.md
@@ -2,7 +2,7 @@
 
 There are multiple ways to create [stacks](../stack/README.md) in Spacelift. Our recommended way is to use [our Terraform provider](../../vendors/terraform/terraform-provider.md) and programmatically create stacks using an [administrative](../stack/stack-settings.md#administrative) stack.
 
-However, sometimes you might want to create a stack manually, or you might want to create a stack temporarily (like pulling up a test environment, then destroying it). In these cases managing a stack from a VCS system and Terraform could be clumsy, this is where Blueprints come in handy.
+However, some users might not be comfortable using Terraform code to create stacks, this is where Blueprints come in handy.
 
 ## What is a Blueprint?
 


### PR DESCRIPTION
# Description of the change

A prospect reported that after reading the introduction to the Blueprints page, they thought it was meant for temporary stacks. This PR clarifies the use case for this feature.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
