### PR TITLE
Clarify a couple of points in the GCP OIDC docs

### DIFF
--- a/docs/integrations/cloud-providers/oidc/gcp-oidc.md
+++ b/docs/integrations/cloud-providers/oidc/gcp-oidc.md
@@ -41,7 +41,7 @@ Once the Spacelift-GCP OIDC integration is set up, the [Google Cloud Terraform p
 ```json
 {
   "type": "external_account",
-  "audience": "//iam.googleapis.com/projects/${PROJECT_ID}/locations/global/workloadIdentityPools/${WORKER_POOL_ID}/providers/${IDENTITY_PROVIDER_ID}",
+  "audience": "//iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${WORKER_POOL_ID}/providers/${IDENTITY_PROVIDER_ID}",
   "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
   "token_url": "https://sts.googleapis.com/v1/token",
   "credential_source": {
@@ -54,6 +54,12 @@ Once the Spacelift-GCP OIDC integration is set up, the [Google Cloud Terraform p
 }
 ```
 
-Your Spacelift run needs to have access to this file, so you can check it in (there's nothing secret here), [mount it](../../../concepts/configuration/environment.md#mounted-files) on a stack or mount it in a [context](../../../concepts/configuration/context.md) that is then attached to the stack. Note that you will also need to tell the provider how to find this configuration file. This bit is nicely documented in the [Google Cloud Terraform provider docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#credentials){: rel="nofollow"}. And here is an example of us using a Spacelift [context](../../../concepts/configuration/context.md) to mount the file and configure the provider to be attached to an arbitrary number of stacks:
+Your Spacelift run needs to have access to this file, so you can check it in (there's nothing secret here), [mount it](../../../concepts/configuration/environment.md#mounted-files) on a stack or mount it in a [context](../../../concepts/configuration/context.md) that is then attached to the stack.
+
+Note that you will also need to tell the provider how to find this configuration file. You can do this by creating a `GOOGLE_APPLICATION_CREDENTIALS` environment variable, and setting it to the path to your credentials file.
+
+Here is an example of us using a Spacelift [context](../../../concepts/configuration/context.md) to mount the file and configure the provider to be attached to an arbitrary number of stacks:
 
 ![GCP Spacelift settings](../../../assets/screenshots/oidc/gcp-spacelift-settings.png)
+
+For more information about configuring the Terraform provider, please see the [Google Cloud Terraform provider docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#credentials){: rel="nofollow"}.


### PR DESCRIPTION
# Description of the change

- The `audience` parameter in the credential config file needs to use the project number, not the project ID.
- I've tweaked the part about configuring the Terraform provider to explicitly mention setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable. From testing, service account impersonation doesn't work correctly if you use other options like setting the `credentials` property in a provider configuration block.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
