### PR TITLE
Updated API version to v1beta1 for the Kubernetes Operator docs

### DIFF
--- a/docs/concepts/worker-pools.md
+++ b/docs/concepts/worker-pools.md
@@ -422,7 +422,7 @@ Finally, create a WorkerPool resource using the following command:
 
 ```shell
 kubectl apply -f - <<EOF
-apiVersion: workers.spacelift.io/v1alpha1
+apiVersion: workers.spacelift.io/v1beta1
 kind: WorkerPool
 metadata:
   name: test-workerpool
@@ -485,7 +485,7 @@ During normal operations the worker pool controller CPU and memory usage should 
 Resource requests and limits for the `init`, `launcher-grpc` and `worker` containers can be set via your `WorkerPool` definitions, like in the following example:
 
 ```yaml
-apiVersion: workers.spacelift.io/v1alpha1
+apiVersion: workers.spacelift.io/v1beta1
 kind: WorkerPool
 metadata:
   name: test-pool
@@ -546,7 +546,7 @@ See the section on [configuration](#configuration) for more details on how to co
 The following example shows all the configurable options for a WorkerPool:
 
 ```yaml
-apiVersion: workers.spacelift.io/v1alpha1
+apiVersion: workers.spacelift.io/v1beta1
 kind: WorkerPool
 metadata:
   # name defines the name of the pool in Kubernetes - does not need to match the name in Spacelift.
@@ -720,7 +720,7 @@ data:
 Next, create a `WorkerPool` definition, configuring the `ConfigMap` as a volume, and setting the custom env var:
 
 ```yaml
-apiVersion: workers.spacelift.io/v1alpha1
+apiVersion: workers.spacelift.io/v1beta1
 kind: WorkerPool
 metadata:
   labels:


### PR DESCRIPTION
# Description of the change

Updated the CRD API versions to v1beta1 to match the versions of the Kubernetes Operator's latest version.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
