### PR TITLE
Document how to use VCS Agents with k8s workers

### DIFF
--- a/docs/concepts/worker-pools.md
+++ b/docs/concepts/worker-pools.md
@@ -754,6 +754,34 @@ spec:
           value: "/opt/spacelift/policies/initialization/initialization-policy.rego"
 ```
 
+#### Using VCS Agents with Kubernetes Workers
+
+Using VCS Agents with Kubernetes workers is simple, and uses exactly the same approach outlined in the [VCS Agents](#vcs-agents) section. To configure your VCS Agent environment variables in a Kubernetes WorkerPool, add them to the `spec.pod.initContainer.env` section, like in the following example:
+
+```yaml
+apiVersion: workers.spacelift.io/v1beta1
+kind: WorkerPool
+metadata:
+  name: test-pool
+spec:
+  poolSize: 2
+  token:
+    secretKeyRef:
+      name: test-pool
+      key: token
+  privateKey:
+    secretKeyRef:
+      name: test-pool
+      key: privateKey
+  pod:
+    initContainer:
+      env:
+        - name: "SPACELIFT_PRIVATEVCS_MAPPING_NAME_0"
+          value: "gitlab-pool"
+        - name: "SPACELIFT_PRIVATEVCS_MAPPING_BASE_ENDPOINT_0"
+          value: "https://gitlab.myorg.com
+```
+
 ### Configuration options
 
 A number of configuration variables is available to customize how your launcher behaves:


### PR DESCRIPTION
# Description of the change

I've added an example showing how to configure a Kubernetes WorkerPool alongside a VCS Agent.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
