### PR TITLE
Add note about canceling runs of the same type

### DIFF
--- a/docs/concepts/policy/push-policy/README.md
+++ b/docs/concepts/policy/push-policy/README.md
@@ -105,10 +105,12 @@ cancel[run.id] {
 }
 ```
 
-Please note that you cannot cancel module test runs. Only proposed and tracked stack runs can be canceled.
+Please note there are some restrictions on cancelation to be aware of:
 
-!!! info
-    Note that run preemption is _best effort_ and not guaranteed. If the run is either picked up by the worker or approved by a human in the meantime then the cancellation itself is canceled.
+- Module test runs cannot be canceled. Only proposed and tracked stack runs can be canceled.
+- Cancelation works based on a new run pre-empting existing runs. What this means is that if your push policy does not result in any runs being triggered, the cancelation will have no effect.
+- A run can only cancel other runs of the _same type_. For example a proposed run can only cancel other proposed runs, and not tracked runs.
+- Cancelation is _best effort_ and not guaranteed. If the run is either picked up by the worker or approved by a human in the meantime then the cancelation itself is canceled.
 
 ### Corner case: track, don't trigger
 
@@ -557,7 +559,7 @@ track {
 propose { affected }
 propose { affected_pr }
 
-ignore  { 
+ignore  {
     not affected
     not affected_pr
 }


### PR DESCRIPTION
# Description of the change

Cancelation only works for runs of the same type, meaning that a proposed run can't cancel a tracked run. In addition, a run needs to be created in order for cancelation to happen, so I've tried to make these points clear.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [ ] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [ ] The preview looks fine.
- [ ] The tests pass.
- [ ] The commit history is clean and meaningful.
- [ ] The pull request is opened against the `main` branch.
- [ ] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
