### PR TITLE
Mention Kubernetes workers in Self-Hosted changelog

### DIFF
--- a/docs/product/administration/changelog.md
+++ b/docs/product/administration/changelog.md
@@ -13,6 +13,7 @@ description: Find out about the latest changes to the Self-Hosted Spacelift.
 - The settings page is now split into Organization and Personal settings
 - [OpenTofu v1.6.1 support](../../concepts/stack/creating-a-stack.md#opentofu)
 - [PR stack locking](../../concepts/policy/push-policy/README.md#stack-locking)
+- [Support for deploying workers via the Kubernetes operator](../../concepts/worker-pools.md#kubernetes)
 
 ### Fixes
 


### PR DESCRIPTION
# Description of the change

I've added a note to mention that the Kubernetes operator is officially supported in Self-Hosted from v1.0.0.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
