### PR TITLE
Additional pull request placeholders

### DIFF
--- a/docs/concepts/policy/notification-policy.md
+++ b/docs/concepts/policy/notification-policy.md
@@ -527,9 +527,12 @@ pull_request contains {
 
 #### Changing the comment body
 
-You can customize the comment body, even include logs from the [planning](../run/proposed.md#planning) or [applying](../run/tracked.md#applying) phase.
+You can customize the comment body, even include logs from various run phases by including a corresponding placeholder:
 
-A `spacelift::logs::planning` placeholder in the comment body will be replaced with logs from the [planning](../run/proposed.md#planning) phase. The same applies to `spacelift::logs::applying` and the [applying](../run/tracked.md#applying) phase.
+- `spacelift::logs::initializing` placeholder will be replaces with logs from the [initializing](../run/README.md#initializing) phase
+- `spacelift::logs::preparing` placeholder will be replaces with logs from the [preparing](../run/README.md#preparing) phase
+- `spacelift::logs::planning` placeholder will be replaced with logs from the [planning](../run/proposed.md#planning) phase
+- `spacelift::logs::applying` placeholder will be replaced with logs from the [applying](../run/tracked.md#applying) phase
 
 ```opa
 package spacelift


### PR DESCRIPTION
# Description of the change

Added pull request notification placeholders for initializing and preparing run phases.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
