### PR TITLE
Add missing README.md to index links

### DIFF
--- a/docs/concepts/configuration/context.md
+++ b/docs/concepts/configuration/context.md
@@ -57,7 +57,7 @@ This is the only mandatory step in the context creation process; the remaining s
 
 The required _name_ is what you'll see in the context list and in the dropdown when attaching the context to projects. Ensure it's informative enough to immediately convey the purpose of the context, yet short enough to fit neatly in dropdowns without cutting off important information.
 
-The last required field in this step is _space_, allowing you to choose which [space](../spaces/) the context will belong to.
+The last required field in this step is _space_, allowing you to choose which [space](../spaces/README.md) the context will belong to.
 
 The optional _description_ is free-form and supports [Markdown](https://daringfireball.net/projects/markdown/){: rel="nofollow"}. This is an ideal place for a thorough explanation of the context's purpose, perhaps with links or a humorous GIF. In the web GUI, this description appears in several places: on the context list, in the context view, and in the list of attached contexts on the stack view.
 

--- a/docs/concepts/stack/creating-a-stack.md
+++ b/docs/concepts/stack/creating-a-stack.md
@@ -29,7 +29,7 @@ Staring with the most difficult step - naming things. Here's where you give your
 
 You'll be able to change the name and description later, too - with one caveat. Based on the original _name_, Spacelift generates an immutable slug that serves as a unique identifier of this stack. If the name and the slug diverge significantly, things may become confusing.
 
-Here you will be able to choose which [space](../spaces/) your stack belongs to. Initially, you start with a root and a legacy space. The root space is the top-level space of your account, while the legacy space exists for backward compatibility with pre-spaces RBAC.
+Here you will be able to choose which [space](../spaces/README.md) your stack belongs to. Initially, you start with a root and a legacy space. The root space is the top-level space of your account, while the legacy space exists for backward compatibility with pre-spaces RBAC.
 
 Also, this is the opportunity to set a few [labels](stack-settings.md#labels). Labels are useful for searching and grouping things, but also work extremely well with policies.
 
@@ -187,7 +187,7 @@ In this section, you can attach the following policy types:
 
 - [Approval:](../../concepts/policy/approval-policy.md) who can approve or reject a run and how a run can be approved;
 - [Plan:](../../concepts/policy/terraform-plan-policy.md) which changes can be applied;
-- [Push:](../../concepts/policy/push-policy/) how Git push events are interpreted;
+- [Push:](../../concepts/policy/push-policy/README.md) how Git push events are interpreted;
 - [Trigger:](../../concepts/policy/trigger-policy.md) what happens when blocking runs terminate;
 
 Policies can be automatically attached to stacks using the `autoattach:label` special label where `label` is the name of a label attached to stacks and/or modules in your Spacelift account you wish the policy to be attached to.

--- a/docs/concepts/stack/stack-dependencies.md
+++ b/docs/concepts/stack/stack-dependencies.md
@@ -86,7 +86,7 @@ When detecting changes in outputs, we also consider the previous run of the depe
 
 #### Vendor limitations
 
-[Ansible](../../vendors/ansible/) and [Kubernetes](../../vendors/kubernetes/) does not have the concept of outputs, so you cannot reference the outputs of them. They _can_ be on the receiving end though:
+[Ansible](../../vendors/ansible/README.md) and [Kubernetes](../../vendors/kubernetes/README.md) does not have the concept of outputs, so you cannot reference the outputs of them. They _can_ be on the receiving end though:
 
 ```mermaid
 graph TD;

--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -126,7 +126,7 @@ Otherwise, policies could look perfectly fine but block each other with deny rul
 
 ### Can I attach my policy to multiple stacks / modules?
 
-This can be done with the `autoattach` label, you can read more about that [here](../concepts/policy#wildcard-policy-attachments).
+This can be done with the `autoattach` label, you can read more about that [here](../concepts/policy/README.md#wildcard-policy-attachments).
 
 ## Billing
 
@@ -144,7 +144,7 @@ When setting up SSO, future logins will appear as new users since Spacelift cann
 
 The main culprits are usually a push policy or the wrong branch being tracked.
 
-If you do not have a push policy in place, you can attach a push policy with the [default push policy](../concepts/policy/push-policy/#default-git-push-policy) and enable [sampling](../concepts/policy#sampling-policy-inputs) to then review the inputs in the [policy workbench](../concepts/policy#policy-workbench-in-practice) to confirm that Spacelift has recieved the push event. (If you are using GitLab, you need to set up webhooks for every project)
+If you do not have a push policy in place, you can attach a push policy with the [default push policy](../concepts/policy/push-policy/README.md#default-git-push-policy) and enable [sampling](../concepts/policy/README.md#sampling-policy-inputs) to then review the inputs in the [policy workbench](../concepts/policy/README.md#policy-workbench-in-practice) to confirm that Spacelift has received the push event. (If you are using GitLab, you need to set up webhooks for every project)
 
 You can review the branch you are tracking in your stack settings.
 
@@ -152,7 +152,7 @@ We also recommend checking your VCS provider is not currently experiencing any i
 
 ### Does Spacelift support monorepos?
 
-Spacelift does support monorepos. You can set a [project root](../concepts/stack/stack-settings.md) in your stack settings. Our [default push policy](../concepts/policy/push-policy/#default-git-push-policy) will trigger runs on changes within the project root or the project globs. You can review our [policy example repo](https://github.com/spacelift-io/spacelift-policies-example-library){: rel="nofollow"} and see how you can customize this further.
+Spacelift does support monorepos. You can set a [project root](../concepts/stack/stack-settings.md) in your stack settings. Our [default push policy](../concepts/policy/push-policy/README.md#default-git-push-policy) will trigger runs on changes within the project root or the project globs. You can review our [policy example repo](https://github.com/spacelift-io/spacelift-policies-example-library){: rel="nofollow"} and see how you can customize this further.
 
 ## Run
 

--- a/docs/vendors/terraform/module-registry.md
+++ b/docs/vendors/terraform/module-registry.md
@@ -221,7 +221,7 @@ Whenever you add a new functionality, you may want to create a feature branch an
 You can also use [Git push policies](../../concepts/policy/push-policy/README.md) to further customize this.
 
 !!! Tip
-    If you would like to manage your Terraform Module versions using git tags, and would like git tag events to push your module to the Spacelift module registry. Please review our [Tag-driven Terraform Module Release Flow](../../concepts/policy/push-policy/#tag-driven-terraform-module-release-flow).
+    If you would like to manage your Terraform Module versions using git tags, and would like git tag events to push your module to the Spacelift module registry. Please review our [Tag-driven Terraform Module Release Flow](../../concepts/policy/push-policy/README.md#tag-driven-terraform-module-release-flow).
 
 !!! info
     If no test cases are present, the version is immediately marked green.


### PR DESCRIPTION
# Description of the change

This PR fixes a few links that pointed to index files, but were missing `README.md` which is required by MkDocs.

![Screenshot 2024-03-20 at 10 59 05](https://github.com/spacelift-io/user-documentation/assets/920747/ae5f4b9c-8257-4725-8fa9-84c3f92b337e)

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
