### PR TITLE
Add a troubleshooting note about pod network identity

### DIFF
--- a/docs/concepts/worker-pools.md
+++ b/docs/concepts/worker-pools.md
@@ -1084,6 +1084,25 @@ spec:
   keepSuccessfulPods: true
 ```
 
+##### Networking issues caused by Pod identity
+
+When a run is assigned to a worker, the controller creates a new Pod to process that run. The Pod has labels indicating the worker and run ID, and looks something like this:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    workers.spacelift.io/run-id: 01HN37WC3MCNE3CY9HAHWRF06K
+    workers.spacelift.io/worker: 01HN356WGGNGTXA8PHYRRKEEZ5
+  name: 01hn37wc3mcne3cy9hahwrf06k-preparing-2
+  namespace: default
+spec:
+  ... rest of the pod spec
+```
+
+Because the set of labels are unique for each run being processed, this can cause problems with systems like [Cilium](https://cilium.io/) that use Pod labels to determine the identity of each Pod, leading to your runs having networking issues. If you are using a system like this, you may want to exclude the `workers.spacelift.io/*` labels from being used to determine network identity.
+
 ### Configuration options
 
 A number of configuration variables is available to customize how your launcher behaves:


### PR DESCRIPTION
# Description of the change

Added a section to clarify that a new Pod is created per run, and that this can cause problems with systems that use Pod labels to determine identity since each run Pod has a different set of labels.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
