### PR TITLE
doc: add required/optional fields for WorkerPool CRD

### DIFF
--- a/docs/concepts/worker-pools.md
+++ b/docs/concepts/worker-pools.md
@@ -553,15 +553,18 @@ metadata:
   name: test-workerpool
 spec:
   # poolSize specifies the current number of Workers that belong to the pool.
+  # Optional, defaults to 1 if not provided.
   poolSize: 2
 
   # token points at a Kubernetes Secret key containing the worker pool token.
+  # Required
   token:
     secretKeyRef:
       name: test-workerpool
       key: token
 
   # privateKey points at a Kubernetes Secret key containing the worker pool private key.
+  # Required
   privateKey:
     secretKeyRef:
       name: test-workerpool
@@ -569,6 +572,7 @@ spec:
 
   # allowedRunnerImageHosts defines the hostnames of registries that are valid to use stack
   # runner images from. If no specified images from any registries are allowed.
+  # Optional
   allowedRunnerImageHosts:
     - docker.io
     - some.private.registry
@@ -577,6 +581,7 @@ spec:
   # as they complete successfully, or be kept so that they can be inspected later. By default
   # run Pods are removed as soon as they complete successfully. Failed Pods are not automatically
   # removed to allow debugging.
+  # Optional
   keepSuccessfulPods: false
 
   # pod contains the spec of Pods that will be created to process Spacelift runs. This allows
@@ -584,6 +589,7 @@ spec:
   # Most of these settings are just standard Kubernetes Pod settings and are not explicitly
   # explained below unless they are particularly important or link directly to a Spacelift
   # concept.
+  # Optional
   pod:
     # activeDeadlineSeconds defines the length of time in seconds before which the Pod will
     # be marked as failed. This can be used to set a deadline for your runs. The default is


### PR DESCRIPTION
# Description of the change

Adds more info in the `WorkerPool` CRD doc to show required and optional fields.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [ ] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [ ] The preview looks fine.
- [ ] The tests pass.
- [ ] The commit history is clean and meaningful.
- [ ] The pull request is opened against the `main` branch.
- [ ] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
