### PR TITLE
Improve documentation about k8s volume configuration

### DIFF
--- a/docs/concepts/worker-pools.md
+++ b/docs/concepts/worker-pools.md
@@ -534,10 +534,64 @@ In general, we don't suggest setting very low CPU or memory limits for the `init
 
 There are two volumes that are always attached to your run Pods:
 
-- The binaries cache volume - used to cache binaries (e.g. `terraform` and `kubectl`) across multiple runs.
-- The workspace volume - used to store the temporary workspace data needed for processing a run.
+- The workspace volume.
+- The binaries cache volume.
 
-Both of these volumes default to using `emptyDir` storage with no size limit, but you should not use this default behaviour for production workloads, and should instead specify volume templates that make sense depending on your use-case.
+Both of these volumes default to using `emptyDir` storage with no size limit. Spacelift workers will function correctly without using a custom configuration for these volumes, but there may be situations where you wish to change this default, for example:
+
+- To prevent Kubernetes evicting your run Pods due to disk pressure (and therefore causing runs to fail).
+- To support caching tool binaries (for example Terraform or OpenTofu) between runs.
+
+##### Workspace Volume
+
+The workspace volume is used to store the temporary workspace data needed for processing a run. This includes metadata about the run, along with your source code. The workspace volume does not need to be shared or persisted between runs, and for that reason we recommend using an [Ephemeral Volume](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/) so that the volume is bound to the lifetime of the run, and will be destroyed when the run Pod is deleted.
+
+The workspace volume can be configured via the `spec.pod.workspaceVolume` property, which accepts a standard Kubernetes volume definition. Here's an example of using an ephemeral AWS GP2 volume for storage:
+
+```yaml
+apiVersion: workers.spacelift.io/v1beta1
+kind: WorkerPool
+metadata:
+  name: worker-pool
+spec:
+  poolSize: 1
+  privateKey:
+    secretKeyRef:
+      key: privateKey
+      name: pool-credentials
+  token:
+    secretKeyRef:
+      key: token
+      name: pool-credentials
+  pod:
+    securityContext:
+      # The fsGroup may or may not be required depending on your volume type. The reason for
+      # specifying it is because the containers in the run pods run as the Spacelift (UID 1983)
+      # user. Depending on the volume type in use, you may experience permission errors during
+      # runs if the fsGroup is not specified.
+      fsGroup: 1983
+
+    # The workspaceVolume property is used to specify the volume to use for the run's workspace.
+    workspaceVolume:
+      name: workspace
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+            - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+            storageClassName: gp2
+```
+
+##### Binaries Cache Volume
+
+The binaries cache volume is used to cache binaries (e.g. `terraform` and `kubectl`) across multiple runs. You can use an ephemeral volume for the binaries cache like with the workspace volume, but doing so will not result in any caching benefits. To be able to share the binaries cache with multiple run pods, you need to use a volume type that supports `ReadWriteMany`, for example AWS EFS.
+
+To configure the binaries cache volume, you can use exactly the same approach as with the [workspace volume](#workspace-volume), the only difference is that you should use the `spec.pod.binariesCacheVolume` property instead of `spec.pod.workspaceVolume`.
+
+##### Custom Volumes
 
 See the section on [configuration](#configuration) for more details on how to configure these two volumes along with any additional volumes you require.
 


### PR DESCRIPTION
# Description of the change

I've tried to improve the docs about how to configure the binaries cache and workspace volumes for Kubernetes workers. I've removed the text that recommended configuring these volumes for production, and instead tried to explain reasons that you might want to configure them to allow users to make their own decisions.

I've also added an example showing how to configure a worker pool using GP2 storage for the workspace volume.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
