### PR TITLE
Document change in precedence rules between config versions

### DIFF
--- a/docs/concepts/configuration/README.md
+++ b/docs/concepts/configuration/README.md
@@ -13,6 +13,6 @@ This section focuses on three aspects of configuration, each of which warrants i
 Some configuration settings can be defined on multiple levels. If they're _over-defined_ (the same setting is defined multiple times), the end result will depend on generic rules of precedence. These rules will be the same for all applicable settings:
 
 - stack-specific [runtime configuration](runtime-configuration/README.md) will take the highest precedence;
-- configuration defined directly (either through the [environment](environment.md), or [settings](../stack/stack-settings.md)) on the stack will go second;
-- common runtime configuration will go next;
+- common runtime configuration will go second;
+- configuration defined directly (either through the [environment](environment.md), or [settings](../stack/stack-settings.md)) on the stack will go next;
 - anything defined at the [context](context.md) level will take the lowest precedence - furthermore, contexts can be attached with a [priority level](context.md#a-note-on-priority) further defining the exact precedence;

--- a/docs/concepts/configuration/runtime-configuration/README.md
+++ b/docs/concepts/configuration/runtime-configuration/README.md
@@ -3,7 +3,7 @@
 The runtime configuration is an optional setup applied to individual runs instead of being global to the stack. It's defined in `.spacelift/config.yml` YAML file at the root of your repository. A single file is used to define settings for all stacks associated with its host Git repository, so the file structure looks like this:
 
 ```yaml title=".spacelift/config.yml"
-version: "1"
+version: "2"
 
 stack_defaults:
     runner_image: your/first:runner
@@ -35,13 +35,19 @@ stacks:
 
 ```
 
-The top level of the file contains three keys - `version` which in practice is currently ignored but may be useful in the future, `stacks` containing a mapping of immutable [stack id](../../stack/README.md#name-and-description) to the [stack configuration block](#stacks-configuration-block) and `stack_defaults`, containing the defaults common to all stacks using this source code repository. Note that corresponding stack-specific settings will override any stack defaults.
+The top level of the file contains three keys - `version` (defaults to `1` if not specified), `stacks` containing a mapping of immutable [stack id](../../stack/README.md#name-and-description) to the [stack configuration block](#stacks-configuration-block) and `stack_defaults`, containing the defaults common to all stacks using this source code repository. Note that corresponding stack-specific settings will override any stack defaults.
 
 Considering the precedence of settings, below is the order that will be followed, starting from the most important to the least important:
 
 1. The configuration for a specified stack defined in config.yml
-2. The stack configuration set in the Spacelift UI.
-3. The stack defaults defined config.yml
+2. The stack defaults defined config.yml
+3. The stack configuration set in the Spacelift UI.
+
+!!! info
+    Please note that the precedence of the runtime configuration file changed between versions 1 and 2.
+    Previously the stack configuration set in the Spacelift UI had a higher precedence than the stack
+    defaults defined in the config.yml file. Starting with version 2, the values in the config.yml file
+    always take precedence over stack settings defined outside the config.yml file.
 
 In cases where there is no stack slug defined in the config, only the first two sources are considered:
 


### PR DESCRIPTION
# Description of the change

We've added a v2 version of the config.yml file that brings the stack runtime config in line with the runtime config used for module tests cases, and grants stack defaults higher precedence than the current stack settings. This makes it possible to change settings across all stacks in one place, but is opt-in (via the version) for backwards compatibility.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
