### PR TITLE
Terragrunt OpenTofu: Make it clear that defaulting to latest version in TF provider only applies on creation

### DIFF
--- a/docs/vendors/terragrunt/reference.md
+++ b/docs/vendors/terragrunt/reference.md
@@ -24,3 +24,8 @@ There is an environment variable for each phase of the run:
 - `TG_CLI_ARGS_init` - Allows you to add options sent to the Terragrunt application during the initialization phase
 - `TG_CLI_ARGS_plan` - Allows you to add options sent to the Terragrunt application during the planning phase
 - `TG_CLI_ARGS_apply` - Allows you to add options sent to the Terragrunt application during the applying phase
+
+## Terraform provider
+
+If you create a Terragrunt stack via the Terraform provider, and don't populate the `terraform_version` or `terragrunt_version` properties, we default to the latest version available at creation time. If you create a stack with these values populated, and then later remove the fields, the stack continues to use the version set during stack creation, and doesn't update to the latest available version.
+If you change the `tool` and `terraform_version` isn't populated, the `terraform_version` will be reset in state file.


### PR DESCRIPTION
# Description of the change

Let's make it clearer: what does it mean if we don't specify terraform/terragrunt version?

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [ ] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [ ] The preview looks fine.
- [ ] The tests pass.
- [ ] The commit history is clean and meaningful.
- [ ] The pull request is opened against the `main` branch.
- [ ] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
