### PR TITLE
Fix GitHub Actions workflow warnings

### DIFF
--- a/.github/workflows/deploy-to-environment.yaml
+++ b/.github/workflows/deploy-to-environment.yaml
@@ -50,7 +50,7 @@ jobs:
           path: ${{ env.RELEASE_BRANCH_NAME }}
 
       - name: Set Python up
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
 

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -31,7 +31,7 @@ jobs:
           separator: "' '"
 
       - name: Set Python up
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         id: set-python-up
         with:
           cache: pip

--- a/.github/workflows/self-hosted-release.yaml
+++ b/.github/workflows/self-hosted-release.yaml
@@ -49,7 +49,7 @@ jobs:
           SPACELIFT_DISTRIBUTION: SELF_HOSTED
 
       - name: Set Python up
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
 


### PR DESCRIPTION
# Description of the change

Fixes GitHub Actions workflow warnings:
![CleanShot 2024-05-29 at 12 47 34@2x](https://github.com/spacelift-io/user-documentation/assets/174728/4f49559b-8bfb-45e9-9a8a-24dced4375c6)

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
