### PR TITLE
Update task-run-policy.md deprecated re_match to regex.match

### DIFF
--- a/docs/concepts/policy/task-run-policy.md
+++ b/docs/concepts/policy/task-run-policy.md
@@ -90,7 +90,7 @@ deny[sprintf("command not allowed (%s)", [command])] {
   command := input.request.command
 
   not input.session.admin
-  not re_match("^terraform\\s(un)?taint\\s[\\w\\-\\.]*$", command)
+  not regex.match("^terraform\\s(un)?taint\\s[\\w\\-\\.]*$", command)
 }
 ```
 
@@ -113,8 +113,8 @@ deny["no tasks on weekends"] {
 }
 
 allowed { input.session.admin }
-allowed { re_match("^terraform\\s(un)?taint\\s[\\w\\-\\.]*$", command) }
-allowed { re_match("^terraform\\simport\\s[\\w\\-\\.]*$", command) }
+allowed { regex.match("^terraform\\s(un)?taint\\s[\\w\\-\\.]*$", command) }
+allowed { regex.match("^terraform\\simport\\s[\\w\\-\\.]*$", command) }
 ```
 
 As usual, this example is [available to play around with](https://play.openpolicyagent.org/p/FP7xz7oWGp){: rel="nofollow"}.
@@ -130,7 +130,7 @@ package spacelift
 
 reject {
   command := input.run.command
-  not re_match("^terraform\\s(un)?taint\\s[\\w\\-\\.]*$", command)
+  not regex.match("^terraform\\s(un)?taint\\s[\\w\\-\\.]*$", command)
 }
 
 approve { not reject }


### PR DESCRIPTION
https://play.openpolicyagent.org/p/MPoP9yQpEp

https://www.openpolicyagent.org/docs/v0.22.0/policy-reference/

https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-regex-regexmatch

# Description of the change

<!-- Please describe the changes that are being added by this PR -->

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
