### PR TITLE
Update tip for running oxipng locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ You can also manually trigger the tests at any time by running:
 pre-commit
 ```
 
-> Tip: one of our precommit checks is `oxipng` which optimizes PNG images. If you don't want to use `pre-commit` locally, you can optimize your PNG images with `docker run --rm -it -v $(PWD):/workdir -w /workdir videah/oxipng docs/assets/screenshots/filename.png --opt=4 --preserve --strip=safe`.
+> Tip: one of our precommit checks is `oxipng` which optimizes PNG images. If you don't want to use `pre-commit` locally, you can optimize your PNG images with `docker run --rm -it -v $(PWD):/workdir -w /workdir peterdemesl/oxipng docs/assets/screenshots/filename.png --opt=4 --preserve --strip=safe`.
 
 ## Self-Hosted
 


### PR DESCRIPTION
# Description of the change

Latest published version of the `videah/oxipng` docker image is 2 years old and it's using `7.0.0`. The latest published version is `9.1.1`. Our pipeline uses a more recent version than `7.0.0` which causes the linter to throw an error.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [ ] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [ ] The preview looks fine.
- [ ] The tests pass.
- [ ] The commit history is clean and meaningful.
- [ ] The pull request is opened against the `main` branch.
- [ ] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
