### PR TITLE
Edited Slack Docs

### DIFF
--- a/docs/integrations/chatops/slack.md
+++ b/docs/integrations/chatops/slack.md
@@ -22,7 +22,7 @@ Once you install the Spacelift app, the account-level integration is finished an
 
 ![](../../assets/screenshots/Mouse_Highlight_Overlay_and_Slack_integration_·_spacelift-io.png)
 
-Installing the Slack app doesn't automatically cause Spacelift to flood your Slack channels with torrents of notifications. These are set up on a per-stack basis using [Slack commands](slack.md#available-commands) and the management uses the Slack interface.
+Installing the Slack app doesn't automatically cause Spacelift to flood your Slack channels with torrents of notifications. These are set up on a per-stack basis using [Notification policies](https://docs.spacelift.io/concepts/policy/notification-policy#slack-messages).
 
 Though before that happens, you need to allow requests coming from Slack to access Spacelift stacks.
 
@@ -142,19 +142,3 @@ space_write["Y"] {
   input.slack.team.id == "X"
 }
 ```
-
-## Available slash commands
-
-!!! warning
-    It's recommended to instead use the [notification policy](../../concepts/policy/notification-policy.md) in order to
-    manage slack messages received from Spacelift. These slash commands are **deprecated**.
-
-    {% if is_self_hosted() %}
-    Also, please note that slash commands only work if your Spacelift instance is publicly accessible by Slack. If your Spacelift installation uses an internal load balancer, for example, slash commands will not work.
-    {% endif %}
-
-Three slash commands are currently available:
-
-- `/spacelift subscribe $stackId` - subscribes a particular Slack channel to run state changes for a given Stack - requires ;
-- `/spacelift unsubscribe $stackId` - unsubscribes a particular Slack channel from run state changes for a given Stack;
-- `/spacelift trigger $stackId` - triggers a tracked run for the specified Stack;


### PR DESCRIPTION
# Description of the change
[At the bottom of our documentation](https://docs.spacelift.io/integrations/chatops/slack.html#available-slash-commands) for slack we say "Available Slash Commands", then there is little message that says:
>It's recommended to instead use the [notification policy](https://docs.spacelift.io/concepts/policy/notification-policy) in order to manage slack messages received from Spacelift. These slash commands are deprecated.

After that it says:

> Three slash commands are currently available:
> /spacelift subscribe $stackId - subscribes a particular Slack channel to run state changes for a given Stack - requires ;
> /spacelift unsubscribe $stackId - unsubscribes a particular Slack channel from run state changes for a given Stack;
> /spacelift trigger $stackId - triggers a tracked run for the specified Stack;

This is misleading if slack commands are deprecated so I just removed it altogether.

In addition, there is a paragraph that says:

> Installing the Slack app doesn't automatically cause Spacelift to flood your Slack channels with torrents of notifications. These are set up on a per-stack basis using [Slack commands](https://docs.spacelift.io/integrations/chatops/slack#available-commands) and the management uses the Slack interface.

That hyperlink under "Slack commands" directs the user nowhere.  So I adjusted that as well to direct a user to a helpful link.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.
