### PR TITLE
Document Self-Hosted webhooks_endpoint option

### DIFF
--- a/docs/product/administration/install.md
+++ b/docs/product/administration/install.md
@@ -146,6 +146,23 @@ The mandatory fields are:
 
 #### Optional configuration options
 
+##### Webhooks URL
+
+By default Spacelift if configured to receive webhooks on the URL specified by the `spacelift_hostname` configuration option. If you want to receive webhooks via a different URL, you can specify the `webhooks_endpoint` property:
+
+```json
+{
+  "spacelift_hostname": "spacelift.myorg.com",
+  "webhooks_endpoint": "webhooks.spacelift.myorg.com"
+}
+```
+
+!!! warning
+    Please note, this URL is used by Spacelift to build the webhook endpoints displayed within
+    the Spacelift user interface. This setting does not affect how traffic is routed to your
+    Spacelift instance, and you are responsible for configuring DNS and any other infrastructure
+    required to route the webhooks traffic to your Spacelift server instance.
+
 ##### Load balancer
 
 Load balancer configuration has a mix of required and optional fields alongside some which


### PR DESCRIPTION
# Description of the change

I've added documentation for the new `webhooks_endpoint` option that will be released in the next version of Self-Hosted.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
