### PR TITLE
Update worker network requirements for DR changes

### DIFF
--- a/docs/concepts/worker-pools/README.md
+++ b/docs/concepts/worker-pools/README.md
@@ -153,8 +153,11 @@ Your worker needs access to the following AWS services in order to function corr
 
 - Access to the public Elastic Container Registry if using our default runner image.
 - Access to `app.spacelift.io`, `<your account name>.app.spacelift.io`, and `downloads.spacelift.io` which point at CloudFront.
-- Access to the [AWS IoT Core endpoints](https://docs.aws.amazon.com/general/latest/gr/iot-core.html){: rel="nofollow"} in eu-west-1 for worker communication via MQTT.
-- Access to [Amazon S3](https://docs.aws.amazon.com/general/latest/gr/s3.html){: rel="nofollow"} in eu-west-1 for uploading run logs.
+- Access to `worker-iot.spacelift.io`. This points at the [AWS IoT Core endpoints](https://docs.aws.amazon.com/general/latest/gr/iot-core.html){: rel="nofollow"} for worker communication via MQTT.
+- Access to [Amazon S3](https://docs.aws.amazon.com/general/latest/gr/s3.html){: rel="nofollow"} for uploading run logs.
+
+!!! info
+    You should allow access to the IoT Core and S3 endpoints in both the `eu-west-1` and `eu-central-1` regions. Typically we use services in `eu-west-1`, however in the case of a full regional outage of `eu-west-1` we would failover to the `eu-central-1` region.
 
 {% else %}
 


### PR DESCRIPTION
# Description of the change

I've updated the worker network security section to mention our new worker endpoint (`worker-iot.spacelift.io`), and to also explain that the AWS services in multiple regions need to be allowed in case of a DR failover.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
