### PR TITLE
Document IoT broker endpoint

### DIFF
--- a/docs/product/administration/install.md
+++ b/docs/product/administration/install.md
@@ -153,7 +153,8 @@ By default Spacelift if configured to receive webhooks on the URL specified by t
 ```json
 {
   "spacelift_hostname": "spacelift.myorg.com",
-  "webhooks_endpoint": "webhooks.spacelift.myorg.com"
+  "webhooks_endpoint": "webhooks.spacelift.myorg.com",
+  ... other settings
 }
 ```
 
@@ -162,6 +163,25 @@ By default Spacelift if configured to receive webhooks on the URL specified by t
     the Spacelift user interface. This setting does not affect how traffic is routed to your
     Spacelift instance, and you are responsible for configuring DNS and any other infrastructure
     required to route the webhooks traffic to your Spacelift server instance.
+
+##### IoT Broker Endpoint
+
+Spacelift uses AWS IoT Core to communicate with workers in order to schedule runs. By default Spacelift will use the IoT broker endpoint for the installation region of your AWS account, but you can also use your own custom IoT broker endpoint, for example `worker-iot.spacelift.myorg.com`.
+
+To configure this, use the following steps:
+
+1. Follow the [AWS documentation](https://docs.aws.amazon.com/iot/latest/developerguide/iot-custom-endpoints-configurable-custom.html) to configure a custom IoT broker endpoint in your Spacelift region, and to setup DNS to point your custom domain name at the broker endpoint.
+2. Specify the `iot_broker_endpoint` setting in your config.json file.
+
+Your config.json file should look something like this:
+
+```json
+{
+  "spacelift_hostname": "spacelift.myorg.com",
+  "iot_broker_endpoint": "worker-iot.spacelift.myorg.com",
+  ... other settings
+}
+```
 
 ##### Load balancer
 


### PR DESCRIPTION
# Description of the change

I've added documentation about how to use a custom domain for the IoT broker.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
