### PR TITLE
Remove `GITHUB_TOKEN` from `setup-spacectl` calls as it isn't required anymore

### DIFF
--- a/docs/concepts/policy/push-policy/run-external-dependencies.md
+++ b/docs/concepts/policy/push-policy/run-external-dependencies.md
@@ -86,8 +86,6 @@ jobs:
     steps:
       - name: Install spacectl
         uses: spacelift-io/setup-spacectl@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -120,8 +118,6 @@ jobs:
     steps:
       - name: Install spacectl
         uses: spacelift-io/setup-spacectl@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/docs/concepts/spacectl.md
+++ b/docs/concepts/spacectl.md
@@ -64,8 +64,6 @@ We have [setup-spacectl](https://github.com/spacelift-io/setup-spacectl){: rel="
 steps:
   - name: Install spacectl
     uses: spacelift-io/setup-spacectl@main
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   - name: Deploy infrastructure
     env:

--- a/docs/integrations/api.md
+++ b/docs/integrations/api.md
@@ -207,8 +207,6 @@ jobs:
 
       - name: Install spacectl
         uses: spacelift-io/setup-spacectl@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: List stacks
         env:

--- a/docs/vendors/terraform/provider-registry.md
+++ b/docs/vendors/terraform/provider-registry.md
@@ -203,8 +203,6 @@ jobs:
 
       - name: Install spacectl
         uses: spacelift-io/setup-spacectl@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
         # We will only run GoReleaser when a tag is pushed. Semantic versioning


### PR DESCRIPTION
# Description of the change

Remove `GITHUB_TOKEN` from `setup-spacectl` calls as it isn't required anymore
## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [ ] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [ ] The preview looks fine.
- [ ] The tests pass.
- [ ] The commit history is clean and meaningful.
- [ ] The pull request is opened against the `main` branch.
- [ ] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
