### PR TITLE
fix: let's specify how terragrunt block works in case stack isn't terragrunt

### DIFF
--- a/docs/concepts/configuration/runtime-configuration/README.md
+++ b/docs/concepts/configuration/runtime-configuration/README.md
@@ -149,4 +149,4 @@ This setting determines the Terragrunt parametrization.
     For example, if you set `terraform_version` only, all other fields will be reset to their defaults.
 
 !!! info
-    Terragrunt specific parameters only work when the stack is a terragrunt stack. Adding this does not override the stack type. For example, Ansible stacks don't become Terragrunt stacks.
+    Terragrunt specific parameters only work when the stack is a Terragrunt stack. Adding this does not override the stack type. For example, Ansible stacks don't become Terragrunt stacks.

--- a/docs/concepts/configuration/runtime-configuration/README.md
+++ b/docs/concepts/configuration/runtime-configuration/README.md
@@ -147,3 +147,7 @@ This setting determines the Terragrunt parametrization.
 !!! warning
     You must set all necessary fields because if the `terragrunt` section is present in the config, it replaces all Terragrunt values rather than merging them.
     For example, if you set `terraform_version` only, all other fields will be reset to their defaults.
+
+!!! info
+    This parametrizes only if a stack is defined as a Terragrunt stack. Adding this does not allow us to override the stack type. For example, Ansible stacks don't become Terragrunt now.
+    It could be helpful for monorepo; it works for Terragrunt stacks only, different ones left untouched.

--- a/docs/concepts/configuration/runtime-configuration/README.md
+++ b/docs/concepts/configuration/runtime-configuration/README.md
@@ -149,5 +149,4 @@ This setting determines the Terragrunt parametrization.
     For example, if you set `terraform_version` only, all other fields will be reset to their defaults.
 
 !!! info
-    This parametrizes only if a stack is defined as a Terragrunt stack. Adding this does not allow us to override the stack type. For example, Ansible stacks don't become Terragrunt now.
-    It could be helpful for monorepo; it works for Terragrunt stacks only, different ones left untouched.
+    Terragrunt specific parameters only work when the stack is a terragrunt stack. Adding this does not override the stack type. For example, Ansible stacks don't become Terragrunt stacks.


### PR DESCRIPTION
# Description of the change

https://github.com/spacelift-io/terraform-provider-spacelift/issues/540#issuecomment-2137455063
The customer suggested that it's not obvious `terragrunt` block isn't applied for different (Terraform, Ansible... ) stack types.
Especially, it makes sense for monorepos, where we could mix different configurations.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [ ] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [ ] The preview looks fine.
- [ ] The tests pass.
- [ ] The commit history is clean and meaningful.
- [ ] The pull request is opened against the `main` branch.
- [ ] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
