### PR TITLE
Added hint box to OIDC pages

### DIFF
--- a/docs/integrations/cloud-providers/oidc/aws-oidc.md
+++ b/docs/integrations/cloud-providers/oidc/aws-oidc.md
@@ -1,5 +1,8 @@
 # Amazon Web Services (AWS)
 
+!!! hint
+    This feature is only available to paid Spacelift accounts. Please check out our [pricing page](https://spacelift.io/pricing){: rel="nofollow"} for more information.
+
 !!! warning
     <!-- markdownlint-disable-next-line MD044 -->
     <!-- KLUDGE: https://github.com/hashicorp/terraform/pull/31276 -->

--- a/docs/integrations/cloud-providers/oidc/azure-oidc.md
+++ b/docs/integrations/cloud-providers/oidc/azure-oidc.md
@@ -1,5 +1,8 @@
 # Microsoft Azure
 
+!!! hint
+    This feature is only available to paid Spacelift accounts. Please check out our [pricing page](https://spacelift.io/pricing){: rel="nofollow"} for more information.
+
 ## Configuring workload identity federation
 
 In order to enable Spacelift runs to access Azure resources, you need to set up Spacelift as a valid identity provider for your account. This is done using [workload identity federation](https://learn.microsoft.com/en-us/azure/active-directory/develop/workload-identity-federation){: rel="nofollow"}. The set up process involves creating an App Registration, and then adding federated credentials that tell Azure which Spacelift runs should be able to use which App Registrations. This process can be completed via the Azure Portal, Azure CLI or Terraform. For illustrative purposes we will use the Azure Portal.

--- a/docs/integrations/cloud-providers/oidc/vault-oidc.md
+++ b/docs/integrations/cloud-providers/oidc/vault-oidc.md
@@ -1,5 +1,8 @@
 # HashiCorp Vault
 
+!!! hint
+    This feature is only available to paid Spacelift accounts. Please check out our [pricing page](https://spacelift.io/pricing){: rel="nofollow"} for more information.
+
 ## Configuring Spacelift as an Identity Provider
 
 In order to enable Spacelift runs to access Vault, you need to set up Spacelift as a valid identity provider for your Vault instance. This is done using [Vault's OIDC auth method](https://www.vaultproject.io/docs/auth/jwt){: rel="nofollow"}. The set up process involves creating a role in Vault that tells Vault which Spacelift runs should be able to access which Vault secrets. This process can be completed via the Vault CLI or Terraform. For illustrative purposes we will use the Vault CLI.


### PR DESCRIPTION
# Description of the change

Our OIDC subpages (AWS, Azure, Vault) currently lack reminders that OIDC integrations are only available for paid Spacelift accounts. Some documentation links bypass the parent OIDC page, which includes this important information, leading users to potentially miss that these features require a paid account.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
