### PR TITLE
Explain restriction with CloudFormation S3 bucket names

### DIFF
--- a/docs/vendors/cloudformation/README.md
+++ b/docs/vendors/cloudformation/README.md
@@ -26,3 +26,7 @@ You can also use Spacelift to mix and match Terraform, Pulumi, and CloudFormatio
 ## Does Spacelift support CloudFormation frameworks?
 
 Yes! We support [AWS CDK](https://github.com/aws/aws-cdk){: rel="nofollow"}, [AWS Serverless Application Model (SAM)](https://aws.amazon.com/serverless/sam/){: rel="nofollow"}, and the [Serverless Framework](https://www.serverless.com/){: rel="nofollow"}. You can read more about it in the relevant subpages of this document.
+
+## Template bucket limitations
+
+Spacelift uses a user-provided S3 bucket to upload templates to as part of applying your changes. When creating this bucket, please make sure that the bucket name does not contain any periods (`.`). Using a bucket name containing periods will cause the template upload to fail.

--- a/docs/vendors/cloudformation/getting-started.md
+++ b/docs/vendors/cloudformation/getting-started.md
@@ -18,6 +18,9 @@ In the first screen, you should select the repository you've just forked, as can
 
 In the next screen, you should choose the **CloudFormation** backend. There, fill in the **Region** field with the AWS region you want to create the CloudFormation Stack in. You should also create an Amazon S3 bucket for template storage and provide its name in the **Template Bucket** field. **We won't automatically create this bucket.**
 
+!!! warning
+    Please make sure that the name of the S3 bucket you use as your template bucket does not contain any periods (`.`). Using bucket names with periods will cause template uploads to fail.
+
 The **Entry Template File** should be set to _main.yaml_ (based on the code in our repository) and the **Stack Name** to a unique CloudFormation Stack name in your AWS account. We'll use _cloudformation-example_ in the pictures.
 
 ![Configuring the backend settings.](<../../assets/screenshots/Screenshot 2021-12-08 at 15.09.23.png>)


### PR DESCRIPTION
# Description of the change

Currently the CloudFormation integration can't upload templates to S3 buckets containing `.`. I've added a section to the CloudFormation docs explaining this along with a callout in the getting started guide.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [ ] The preview looks fine.
- [ ] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
