### PR TITLE
Make it more obvious that k8s resource limits can cause run failures

### DIFF
--- a/docs/concepts/worker-pools/kubernetes-workers.md
+++ b/docs/concepts/worker-pools/kubernetes-workers.md
@@ -190,30 +190,40 @@ spec:
         requests:
           cpu: 500m
           memory: 200Mi
-        limits:
-          cpu: 500m
-          memory: 200Mi
+        # Please note: we recommend being very cautious when adding resource limits
+        # to your containers. Setting too low a limit on the init container can cause
+        # runs to fail during the preparing phase.
+        # limits:
+        #   cpu: 100m
+        #   memory: 50Mi
     grpcServerContainer:
       resources:
         requests:
-          cpu: 100m
-          memory: 50Mi
-        limits:
-          cpu: 100m
-          memory: 50Mi
+          cpu: 500m
+          memory: 200Mi
+        # Setting too low limits on the grpc server container can cause runs to fail
+        # when moving into the unconfirmed stage, as well as problems like not being
+        # able to stop/cancel runs.
+        # limits:
+        #   cpu: 100m
+        #   memory: 50Mi
     workerContainer:
       resources:
         requests:
           cpu: 500m
           memory: 200Mi
-        limits:
-          cpu: 500m
-          memory: 200Mi
+        # Setting too low limits on the worker container can cause problems executing
+        # your IaC tool (e.g. OpenTofu, Terraform, etc), causing runs to fail during
+        # planning, applying or destroying phases.
+        # limits:
+        #   cpu: 500m
+        #   memory: 200Mi
 ```
 
 You can use the values above as a baseline to get started, but the exact values you need for your pool will depend on your individual circumstances. You should use monitoring tools to adjust these to values that make sense.
 
-In general, we don't suggest setting very low CPU or memory limits for the `init` or `worker` containers since doing so could affect the performance of runs, or even cause runs to fail if they are set too low. And in particular, the worker container resource usage will very much depend on your workloads. For example stacks with large numbers of Terraform resources may use more memory than smaller stacks.
+!!! warning
+    In general, we don't suggest setting very low CPU or memory limits for the `init`, `grpc` or `worker` containers since doing so could affect the performance of runs, or even cause runs to fail if they are set too low. And in particular, the worker container resource usage will very much depend on your workloads. For example stacks with large numbers of Terraform resources may use more memory than smaller stacks.
 
 ## Volumes
 


### PR DESCRIPTION
# Description of the change

I want to highlight that setting very low Kubernetes CPU or memory limits can cause performance issues when executing runs. I've also commented out the limits by default in the examples to make it less likely they are blindly copied and used without being adjusted.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
