### PR TITLE
Sort permissions to set alphabetically so it's easier to follow

### DIFF
--- a/docs/concepts/policy/approval-policy.md
+++ b/docs/concepts/policy/approval-policy.md
@@ -150,7 +150,7 @@ This is the schema of the data input that each policy request will receive:
 ## Examples
 
 !!! tip
-    We maintain a [library of example policies](https://github.com/spacelift-io/spacelift-policies-example-library/tree/main/approval){: rel="nofollow"} that are ready to use or that you could tweak to meet your specific needs.
+    We maintain a [library of example policies](https://github.com/spacelift-io/spacelift-policies-example-library/tree/main/examples/approval){: rel="nofollow"} that are ready to use or that you could tweak to meet your specific needs.
 
     If you cannot find what you are looking for below or in the library, please reach out to [our support](../../product/support/README.md#contact-support) and we will craft a policy to do exactly what you need.
 

--- a/docs/concepts/policy/login-policy.md
+++ b/docs/concepts/policy/login-policy.md
@@ -90,7 +90,7 @@ For Single Sign-On, the list of teams is pretty much arbitrary and depends on ho
 ## Examples
 
 !!! tip
-    We maintain a [library of example policies](https://github.com/spacelift-io/spacelift-policies-example-library/tree/main/login){: rel="nofollow"} that are ready to use or that you could tweak to meet your specific needs.
+    We maintain a [library of example policies](https://github.com/spacelift-io/spacelift-policies-example-library/tree/main/examples/login){: rel="nofollow"} that are ready to use or that you could tweak to meet your specific needs.
 
     If you cannot find what you are looking for below or in the library, please reach out to [our support](../../product/support/README.md#contact-support) and we will craft a policy to do exactly what you need.
 

--- a/docs/concepts/policy/push-policy/README.md
+++ b/docs/concepts/policy/push-policy/README.md
@@ -494,7 +494,7 @@ It is also possible to define an auxiliary rule called `ignore_track`, which ove
 ## Examples
 
 !!! tip
-    We maintain a [library of example policies](https://github.com/spacelift-io/spacelift-policies-example-library/tree/main/push){: rel="nofollow"} that are ready to use or that you could tweak to meet your specific needs.
+    We maintain a [library of example policies](https://github.com/spacelift-io/spacelift-policies-example-library/tree/main/examples/push){: rel="nofollow"} that are ready to use or that you could tweak to meet your specific needs.
 
     If you cannot find what you are looking for below or in the library, please reach out to [our support](../../../product/support/README.md#contact-support) and we will craft a policy to do exactly what you need.
 

--- a/docs/concepts/policy/stack-access-policy.md
+++ b/docs/concepts/policy/stack-access-policy.md
@@ -83,7 +83,7 @@ This is the schema of the data input that each policy request will receive:
 ## Examples
 
 !!! tip
-    We maintain a [library of example policies](https://github.com/spacelift-io/spacelift-policies-example-library/tree/main/access){: rel="nofollow"} that are ready to use or that you could tweak to meet your specific needs.
+    We maintain a [library of example policies](https://github.com/spacelift-io/spacelift-policies-example-library/tree/main/examples/access){: rel="nofollow"} that are ready to use or that you could tweak to meet your specific needs.
 
     If you cannot find what you are looking for below or in the library, please reach out to [our support](../../product/support/README.md#contact-support) and we will craft a policy to do exactly what you need.
 

--- a/docs/concepts/policy/terraform-plan-policy.md
+++ b/docs/concepts/policy/terraform-plan-policy.md
@@ -366,7 +366,7 @@ The minimal example for the above rule is available in the [Rego playground](htt
 ## Examples
 
 !!! tip
-    We maintain a [library of example policies](https://github.com/spacelift-io/spacelift-policies-example-library/tree/main/plan){: rel="nofollow"} that are ready to use or that you could tweak to meet your specific needs.
+    We maintain a [library of example policies](https://github.com/spacelift-io/spacelift-policies-example-library/tree/main/examples/plan){: rel="nofollow"} that are ready to use or that you could tweak to meet your specific needs.
 
     If you cannot find what you are looking for below or in the library, please reach out to [our support](../../product/support/README.md#contact-support) and we will craft a policy to do exactly what you need.
 

--- a/docs/concepts/policy/trigger-policy.md
+++ b/docs/concepts/policy/trigger-policy.md
@@ -217,7 +217,7 @@ When triggered by a _new module version_, this is the schema of the data input t
 ## Examples
 
 !!! tip
-    We maintain a [library of example policies](https://github.com/spacelift-io/spacelift-policies-example-library/tree/main/trigger){: rel="nofollow"} that are ready to use or that you could tweak to meet your specific needs.
+    We maintain a [library of example policies](https://github.com/spacelift-io/spacelift-policies-example-library/tree/main/examples/trigger){: rel="nofollow"} that are ready to use or that you could tweak to meet your specific needs.
 
     If you cannot find what you are looking for below or in the library, please reach out to [our support](../../product/support/README.md#contact-support) and we will craft a policy to do exactly what you need.
 

--- a/docs/integrations/source-control/github.md
+++ b/docs/integrations/source-control/github.md
@@ -53,7 +53,7 @@ You will be presented with two options:
     The easiest and recommended way to install the custom Spacelift application in your GitHub account is by using the wizard.
 
     You will be asked a few questions, then you will be redirected to GitHub to create the application. Once it's done, you'll be redirected back to Spacelift to finish the integration.
-    
+
     <p align="center">
         <img src="../../assets/screenshots/GitHub_wizard_final_step.png"/>
     </p>
@@ -75,7 +75,7 @@ You will be presented with two options:
     <p align="center"><img src="../../assets/screenshots/CleanShot 2022-09-16 at 10.14.05.png" width="450"></p>
 
     Let's choose a friendly name (it can contain spaces) for your integration and choose the integration type.
-    
+
     The integration type could be either **default** or **space-specific**. The default integration is available to **all** stacks and modules. There can be only one default integration per VCS provider. Space-level integrations however are only available to those stacks and modules that are in the same Space as the integration (or [inherit](../../concepts/spaces/access-control.md#inheritance) permissions through a parent Space). For example if your integration is in `ParentSpace` and your stack is in `ChildSpace` with inheritance enabled, you'll be able to attach the integration to that stack. Refer to the [Spaces documentation](../../concepts/spaces/access-control.md) to learn more about Space access controls and inheritance.
 
     Once the integration name and the type are chosen, a **webhook endpoint** and a **webhook secret** will be generated in the middle of the form. These two are enough to create the GitHub App, so let's do that now.
@@ -99,12 +99,12 @@ You will be presented with two options:
     | Permission      | Access       |
     | --------------- | ------------ |
     | Checks          | Read & write |
+    | Commit statuses | Read & write |
     | Contents        | Read-only    |
     | Deployments     | Read & write |
     | Metadata        | Read-only    |
     | Pull requests   | Read & write |
     | Webhooks        | Read & write |
-    | Commit statuses | Read & write |
 
     **Set the following Organization permissions:**
 
@@ -138,7 +138,7 @@ You will be presented with two options:
 
     !!! info
         If you are using `github.com` set your API host URL as: [https://api.github.com](https://api.github.com){: rel="nofollow"}.
-    
+
     !!! info
         User facing host URL is the URL that will be displayed in the Spacelift UI. Typically, this is the same as the API host URL unless you are using [VCS Agents](../../concepts/vcs-agent-pools.md): in that case, the API host URL will look like `private://vcs-agent-pool-name`, but the User facing host URL can look more friendly (for example `https://vcs-agent-pool.mycompany.com/`) since it isn't actually being used by Spacelift.
 


### PR DESCRIPTION
# Description of the change

When I was setting the github integration manually it was a bit annoying that the last permission was not in the alphabetical order (I had to scroll back to set it), other than that all of the permissions were in the order they appear in github so it was much easier to follow. 

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
