### PR TITLE
Fix incorrect description of glob matching

### DIFF
--- a/docs/concepts/stack/stack-settings.md
+++ b/docs/concepts/stack/stack-settings.md
@@ -242,17 +242,22 @@ The project globs option allows you to specify files and directories outside of 
 
 You aren't required to add any project globs if you don't want to, but you have the option to add as many project globs as you want for a stack.
 
-Under the hood, the project globs option takes advantage of the [doublestar.Match](https://github.com/bmatcuk/doublestar?tab=readme-ov-file#match){: rel="nofollow"} function to do pattern matching.
+When the [default push policy](../policy/push-policy/README.md#default-git-push-policy) is used, project globs are evaluated by the [`glob.match()` OPA function](https://www.openpolicyagent.org/docs/latest/policy-reference/#glob){: rel="nofollow"}.
 
-Example matches:
+Example matches, for the default push policy:
 
-- Any directory or file: `**`
-- A directory and all of its content: `dir/*`
-- Match all files with a specific extension: `dir/*.tf`
-- Match all files that start with a string, end with another and have a predefined number of chars in the middle -- `data-???-report` will match three chars between data and report
-- Match all files that start with a string, and finish with any character from a sequence: `dir/instance[0-9].tf`
+- Any arbitrarily-nested file: `**`
+- A directory and all of its content (not including nested directories): `dir/*`
+- A directory and all of its arbitrarily-nested contents: `dir/**`
+- All files with a specific extension: `**.tf`
+- All files that start with a string, end with another and have a predefined number of chars in the middle -- `**/data-???-report` will match three chars between data and report
+- All files that start with a string, and finish with any character from a sequence: `dir/instance[0-9].tf`
 
-As you can see in the example matches, these are the regex rules that you are already accustomed to.
+As you can see, these are similar to the regex rules that you may already accustomed to.
+
+!!! warning
+    The above description does **not apply** if any custom push policies are attached to the stack.
+    In that case, the project globs are evaluated by the custom push policies in whatever way they evaluate them.
 
 ### VCS integration and repository
 

--- a/docs/concepts/stack/stack-settings.md
+++ b/docs/concepts/stack/stack-settings.md
@@ -250,8 +250,8 @@ Example matches, for the default push policy:
 - A directory and all of its content (not including nested directories): `dir/*`
 - A directory and all of its arbitrarily-nested contents: `dir/**`
 - All files with a specific extension: `**.tf`
-- All files that start with a string, end with another and have a predefined number of chars in the middle -- `**/data-???-report` will match three chars between data and report
-- All files that start with a string, and finish with any character from a sequence: `dir/instance[0-9].tf`
+- Files in the repo root that start with a string, end with another and have three chars in the middle: `data-???-report`
+- Files in the repo root that start with a string, and finish with any character from a sequence: `instance[0-9].tf`
 
 As you can see, these are similar to the regex rules that you may already accustomed to.
 


### PR DESCRIPTION
# Description of the change

The previous description of how globs are matched is incorrect.

Since the underlying "evaluation engine" is simply an OPA policy (which is described [here](https://github.com/spacelift-io/user-documentation/blob/c8ff97128ca05fdc7ec5e17be821f0b6c0500fe1/docs/concepts/policy/push-policy/README.md?plain=1#L564-L609)), the Golang `doublestar` library has nothing to do with the evaluation. OPA uses its own [built-in glob evaluation](https://github.com/open-policy-agent/opa/blob/v0.64.1/wasm/src/glob.cc), which does not follow the same rules as `doublestar`. See [this Rego Playground](https://play.openpolicyagent.org/p/U8q32mgo8L) for examples of where they don't match your docs (the ones reported as "broken").

Additionally, if any custom push policies are attached, the default policy gets thrown out; it's purely up to those policies to interpret the project globs however they see fit (if at all).

This PR modifies the glob section to point to the correct documentation for pattern matching, and updates the examples for quality and accuracy.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [ ] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
