### PR TITLE
fix using tf providers for sh

### DIFF
--- a/docs/vendors/terraform/provider-registry.md
+++ b/docs/vendors/terraform/provider-registry.md
@@ -264,8 +264,7 @@ Terraform providers hosted by Spacelift can be used the same way as providers ho
 terraform {
   required_providers {
     yourprovider = {
-    {% if is_saas() %}source  = "spacelift.io/your-org/yourprovider"{% endif %}
-    {% if is_self_hosted() %}source  = "your-hostname/your-org/yourprovider"{% endif %}
+      source  = {% if is_saas() %}"spacelift.io/your-org/yourprovider"{% endif %} {% if is_self_hosted() %}"your-hostname/your-org/yourprovider"{% endif %}
     }
   }
 }

--- a/docs/vendors/terraform/provider-registry.md
+++ b/docs/vendors/terraform/provider-registry.md
@@ -260,33 +260,20 @@ Once published, your version is ready to use. See the next section for more info
 
 Terraform providers hosted by Spacelift can be used the same way as providers hosted by the Terraform Registry. The only difference is that you need to specify the Spacelift registry URL in your Terraform configuration.
 
-{% if is_saas() %}
-
 ```terraform title="main.tf"
 terraform {
   required_providers {
     yourprovider = {
+    {% if is_saas() %}
       source  = "spacelift.io/your-org/yourprovider"
-    }
-  }
-}
-```
-
-{% endif %}
-
-{% if is_self_hosted() %}
-
-```terraform title="main.tf"
-terraform {
-  required_providers {
-    yourprovider = {
+    {% endif %}
+    {% if is_self_hosted() %}
       source  = "your-hostname/your-org/yourprovider"
+    {% endif %}
     }
   }
 }
 ```
-
-{% endif %}
 
 The above example does not refer to a specific version, meaning that you are going to always use the latest available (published) version of your provider. That said, you can use any versioning syntax supported by the Terraform Registry - learn more about it [here](https://developer.hashicorp.com/terraform/language/expressions/version-constraints){: rel="nofollow"}.
 

--- a/docs/vendors/terraform/provider-registry.md
+++ b/docs/vendors/terraform/provider-registry.md
@@ -264,7 +264,7 @@ Terraform providers hosted by Spacelift can be used the same way as providers ho
 terraform {
   required_providers {
     yourprovider = {
-      source  = {% if is_saas() %}"spacelift.io/your-org/yourprovider"{% endif %} {% if is_self_hosted() %}"your-hostname/your-org/yourprovider"{% endif %}
+      source  = "{% if is_saas() %}spacelift.io{% else %}your-hostname{% endif %}/your-org/yourprovider"
     }
   }
 }

--- a/docs/vendors/terraform/provider-registry.md
+++ b/docs/vendors/terraform/provider-registry.md
@@ -264,11 +264,11 @@ Terraform providers hosted by Spacelift can be used the same way as providers ho
 
 ```terraform title="main.tf"
 terraform {
-required_providers {
-yourprovider = {
+  required_providers {
+    yourprovider = {
       source  = "spacelift.io/your-org/yourprovider"
     }
-}
+  }
 }
 ```
 
@@ -278,11 +278,11 @@ yourprovider = {
 
 ```terraform title="main.tf"
 terraform {
-required_providers {
-yourprovider = {
+  required_providers {
+    yourprovider = {
       source  = "your-hostname/your-org/yourprovider"
     }
-}
+  }
 }
 ```
 

--- a/docs/vendors/terraform/provider-registry.md
+++ b/docs/vendors/terraform/provider-registry.md
@@ -264,12 +264,8 @@ Terraform providers hosted by Spacelift can be used the same way as providers ho
 terraform {
   required_providers {
     yourprovider = {
-    {% if is_saas() %}
-      source  = "spacelift.io/your-org/yourprovider"
-    {% endif %}
-    {% if is_self_hosted() %}
-      source  = "your-hostname/your-org/yourprovider"
-    {% endif %}
+    {% if is_saas() %}source  = "spacelift.io/your-org/yourprovider"{% endif %}
+    {% if is_self_hosted() %}source  = "your-hostname/your-org/yourprovider"{% endif %}
     }
   }
 }

--- a/docs/vendors/terraform/provider-registry.md
+++ b/docs/vendors/terraform/provider-registry.md
@@ -260,15 +260,33 @@ Once published, your version is ready to use. See the next section for more info
 
 Terraform providers hosted by Spacelift can be used the same way as providers hosted by the Terraform Registry. The only difference is that you need to specify the Spacelift registry URL in your Terraform configuration.
 
+{% if is_saas() %}
+
 ```terraform title="main.tf"
 terraform {
-  required_providers {
-    yourprovider = {
+required_providers {
+yourprovider = {
       source  = "spacelift.io/your-org/yourprovider"
     }
-  }
+}
 }
 ```
+
+{% endif %}
+
+{% if is_self_hosted() %}
+
+```terraform title="main.tf"
+terraform {
+required_providers {
+yourprovider = {
+      source  = "your-hostname/your-org/yourprovider"
+    }
+}
+}
+```
+
+{% endif %}
 
 The above example does not refer to a specific version, meaning that you are going to always use the latest available (published) version of your provider. That said, you can use any versioning syntax supported by the Terraform Registry - learn more about it [here](https://developer.hashicorp.com/terraform/language/expressions/version-constraints){: rel="nofollow"}.
 


### PR DESCRIPTION
# Description of the change

Remove spacelift.io hostname for the SH tf provider code snippet 
## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [ ] The tests pass.
- [ ] The commit history is clean and meaningful.
- [ ] The pull request is opened against the `main` branch.
- [ ] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
