### PR TITLE
doc(CU-869756wtw): add a section about workerpool controller metrics

### DIFF
--- a/docs/concepts/worker-pools/kubernetes-workers.md
+++ b/docs/concepts/worker-pools/kubernetes-workers.md
@@ -45,23 +45,22 @@ The controller may also work with older versions, but we do not guarantee and pr
 
     You can open `values.yaml` from the helm chart repo for more customization options.
 
-    **Warning**
-    
-    [Helm has no support at this time for upgrading or deleting crd's](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations) so this would need to be done manually through kubernetes.  
-[The latest CRD's can be found in this link](https://github.com/spacelift-io/spacelift-helm-charts/tree/main/spacelift-workerpool-controller/crds).
+    !!! warning
+        [Helm has no support at this time for upgrading or deleting crd's](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations) so this would need to be done manually through kubernetes.
+        [The latest CRD's can be found in this link](https://github.com/spacelift-io/spacelift-helm-charts/tree/main/spacelift-workerpool-controller/crds).
 
-!!! tip "Prometheus metrics"
-    The controller also has a subchart for our prometheus-exporter project that exposes metrics in OpenMetrics   spec.
-    This is useful for scaling workers based on queue length in spacelift (`spacelift_worker_pool_runs_pending`   metric).
-    To install the controller with the prometheus-exporter subchart, use the following command:
-    ```shell
-    helm upgrade spacelift-workerpool-controller spacelift/spacelift-workerpool-controller --install --namespace   spacelift-worker-controller-system --create-namespace \
-    --set spacelift-promex.enabled=true \
-    --set spacelift-promex.apiEndpoint="https://{yourAccount}.app.spacelift.io" \
-    --set spacelift-promex.apiKeyId="{yourApiToken}" \
-    --set spacelift-promex.apiKeySecretName="spacelift-api-key"
-    ```
-    Read more on the exporter on its repository [here](https://github.com/spacelift-io/prometheus-exporter)   and   see more config options in the `values.yaml` file for the subchart.
+    !!! tip "Prometheus metrics"
+        The controller also has a subchart for our prometheus-exporter project that exposes metrics in OpenMetrics   spec.
+        This is useful for scaling workers based on queue length in spacelift (`spacelift_worker_pool_runs_pending`   metric).
+        To install the controller with the prometheus-exporter subchart, use the following command:
+        ```shell
+        helm upgrade spacelift-workerpool-controller spacelift/spacelift-workerpool-controller --install --namespace   spacelift-worker-controller-system --create-namespace \
+        --set spacelift-promex.enabled=true \
+        --set spacelift-promex.apiEndpoint="https://{yourAccount}.app.spacelift.io" \
+        --set spacelift-promex.apiKeyId="{yourApiToken}" \
+        --set spacelift-promex.apiKeySecretName="spacelift-api-key"
+        ```
+        Read more on the exporter on its repository [here](https://github.com/spacelift-io/prometheus-exporter)   and   see more config options in the `values.yaml` file for the subchart.
 
 ### Create a Secret
 

--- a/docs/concepts/worker-pools/kubernetes-workers.md
+++ b/docs/concepts/worker-pools/kubernetes-workers.md
@@ -50,17 +50,17 @@ The controller may also work with older versions, but we do not guarantee and pr
         [The latest CRD's can be found in this link](https://github.com/spacelift-io/spacelift-helm-charts/tree/main/spacelift-workerpool-controller/crds).
 
     !!! tip "Prometheus metrics"
-        The controller also has a subchart for our prometheus-exporter project that exposes metrics in OpenMetrics   spec.
-        This is useful for scaling workers based on queue length in spacelift (`spacelift_worker_pool_runs_pending`   metric).
+        The controller also has a subchart for our prometheus-exporter project that exposes metrics in OpenMetrics spec.
+        This is useful for scaling workers based on queue length in spacelift (`spacelift_worker_pool_runs_pending` metric).
         To install the controller with the prometheus-exporter subchart, use the following command:
         ```shell
-        helm upgrade spacelift-workerpool-controller spacelift/spacelift-workerpool-controller --install --namespace   spacelift-worker-controller-system --create-namespace \
+        helm upgrade spacelift-workerpool-controller spacelift/spacelift-workerpool-controller --install --namespace spacelift-worker-controller-system --create-namespace \
         --set spacelift-promex.enabled=true \
         --set spacelift-promex.apiEndpoint="https://{yourAccount}.app.spacelift.io" \
         --set spacelift-promex.apiKeyId="{yourApiToken}" \
         --set spacelift-promex.apiKeySecretName="spacelift-api-key"
         ```
-        Read more on the exporter on its repository [here](https://github.com/spacelift-io/prometheus-exporter)   and   see more config options in the `values.yaml` file for the subchart.
+        Read more on the exporter on its repository [here](https://github.com/spacelift-io/prometheus-exporter) and see more config options in the `values.yaml` file for the subchart.
 
 ### Create a Secret
 


### PR DESCRIPTION
# Description of the change

This adds a section to explain how to use the workerpool controller metrics.

I also make the warning a bit more visible in the Helm installation section, and fixed indentation for the promex exporter.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [ ] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [ ] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
