### PR TITLE
doc: make upgrade version more explicit

### DIFF
--- a/docs/concepts/worker-pools/kubernetes-workers.md
+++ b/docs/concepts/worker-pools/kubernetes-workers.md
@@ -149,7 +149,7 @@ Usually, there is nothing special to do for upgrading the controller.
 
 Some release of the controller may include backward compatibility breaks, you can find below instructions about how to upgrade for those specials versions.
 
-### Upgrading to 0.0.17
+### Upgrading to controller v0.0.17 - or Helm chart v0.33.0
 
 This release changes the way the controller exposes metrics by removing usage of the `kube-rbac-proxy` container.
 


### PR DESCRIPTION
# Description of the change

This fixes feedback from @Apollorion where using Helm chart the controller version in use is maybe not explicit enough.

>  I think the only nitpicky thing that I'd mention is that our chart versions and app versions dont align so when we link to the Upgrading to 0.0.17 section of the docs in the release notes its a little confusing because we released 0.33.0 of the chart.
Maybe we make the title of that section Upgrading to app 0.0.17/Chart 0.33.0 or something along those lines.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [ ] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [ ] The preview looks fine.
- [ ] The tests pass.
- [ ] The commit history is clean and meaningful.
- [ ] The pull request is opened against the `main` branch.
- [ ] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
