### PR TITLE
docs: add hint about prepended variable definitions for the policies

### DIFF
--- a/docs/concepts/policy/README.md
+++ b/docs/concepts/policy/README.md
@@ -198,6 +198,39 @@ This takes you to the policy creation screen where you can choose the type of po
 
 Once you're done, click on the _Create policy_ button to save it. Don't worry, policy body is mutable so you'll always be able to edit it if need be.
 
+### Policy structure
+
+We prepend variable definitions to each policy. These variables can be different for each type, but the prepended code is very similar. Here's an example for the [Approval](approval-policy.md) policy:
+
+```opa
+package spacelift
+
+# This is what Spacelift will query for when evaluating policies.
+result = {
+  "approve": approve,
+  "reject": reject,
+  "flag": flag,
+  "sample": sample,
+}
+
+# Default to ensure that "approve" is defined.
+default approve = false
+
+# Default to ensure that "reject" is defined.
+default reject = false
+
+# Default to ensure that "sample" is defined.
+default sample = false
+
+# Placeholder to ensure that "flag" will be a set.
+flag["never"] {
+  false
+}
+```
+
+!!! warning
+    Remember that you can't change predefined variable types. Doing so will result in a policy validation error and the policy won't be saved.
+
 ## Attaching policies
 
 ### Automatically


### PR DESCRIPTION
# Description of the change

Adding hint about prepended variable definitions for the policies. One of the customers ran into conflict errors related to them and we want to give a better explanation what's happening behind the scene.

Here's a corresponding [PR for the policy templates](https://github.com/spacelift-io/frontend/pull/5249)

Here's the outcome:
![image](https://github.com/user-attachments/assets/6d82e216-2a39-4286-9d40-f8e4db761fa5)

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [X] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [X] The preview looks fine.
- [X] The tests pass.
- [X] The commit history is clean and meaningful.
- [X] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [X] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [X] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
