### PR TITLE
Add Troubleshooting to the worker pools section of the docs specifyin…

### DIFF
--- a/docs/concepts/worker-pools/README.md
+++ b/docs/concepts/worker-pools/README.md
@@ -273,5 +273,5 @@ In progress runs will be the first entries in the list when using the view witho
 
 ### Locally, the run completes in 10 minutes, but on Spacelift, it takes over 30 minutes with no new activity appearing in the logs for the entire 30-minute duration (if debug logging is set to on then only showing Still running... in the logs for that duration).
 
-The issue might be related to the instance size and its CPU limitations. Ensure that your instance is set to unlimited mode if it's burstable. If the CPU utilization remains at 100%, consider scaling up to a larger instance size.
+The issue might be related to the instance size and its CPU limitations. It's advisable to monitor CPU and memory usage and make adjustments as needed.
 

--- a/docs/concepts/worker-pools/README.md
+++ b/docs/concepts/worker-pools/README.md
@@ -268,3 +268,10 @@ In progress runs will be the first entries in the list when using the view witho
 [Stacks](../stack/README.md) and/or [Modules](../../vendors/terraform/module-registry.md) that are using the public worker pool.
 
 {% endif %}
+
+## Troubleshooting
+
+### Locally, the run completes in 10 minutes, but on Spacelift, it takes over 30 minutes with no new activity appearing in the logs for the entire 30-minute duration (if debug logging is set to on then only showing Still running... in the logs for that duration).
+
+The issue might be related to the instance size and its CPU limitations. Ensure that your instance is set to unlimited mode if it's burstable. If the CPU utilization remains at 100%, consider scaling up to a larger instance size.
+


### PR DESCRIPTION
# Description of the change

Add Troubleshooting to the worker pools section of the docs specifying information about burstable instances.

internal ref: https://spacelift-io.slack.com/archives/C05TXMEPQNN/p1736546337751149

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [ ] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [ ] The preview looks fine.
- [ ] The tests pass.
- [ ] The commit history is clean and meaningful.
- [ ] The pull request is opened against the `main` branch.
- [ ] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
