### PR TITLE
feat: add `make run` using docker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ To tweak the look and feel of the user documentation, you can:
 You can preview changes locally by running `mkdocs serve`. You can use the following command to run this inside a Docker container:
 
 ```shell
-docker run --pull always --rm -it -p 8000:8000 -v ${PWD}:/docs python:$(cat .python-version | tr -d '\n')-alpine sh -c "apk add git && pip install mkdocs && pip install -r /docs/requirements.txt && cd /docs && mkdocs serve -a '0.0.0.0:8000'"
+make run
 ```
 
 > 💡 These commands are [set up](.vscode/tasks.json) as [VS Code tasks](https://code.visualstudio.com/docs/editor/tasks), so you can just run them from the VS Code command palette. Or even better: download the [Task Explorer](https://marketplace.visualstudio.com/items?itemName=spmeesseman.vscode-taskexplorer) extension and you can run them from the sidebar.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11.2-alpine
+WORKDIR /docs
+
+RUN apk update &&\
+    apk add --no-cache git
+
+COPY requirements.txt .
+RUN pip install mkdocs &&\
+    pip install -r requirements.txt
+
+CMD ["mkdocs", "serve", "-a", "0.0.0.0:8000"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: run
+run:
+	docker compose up

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,14 @@
 .PHONY: run
 run:
 	docker compose up
+
+.PHONY: lint
+lint: markdown-lint oxipng
+
+.PHONY: markdown-lint
+markdown-lint:
+	docker run -v ${PWD}:/app:ro -w /app --rm ghcr.io/tcort/markdown-link-check:stable --config=markdown-link-check.json .
+
+.PHONY: oxipng
+oxipng:
+	docker run --rm -v $(pwd):/app -w /app ghcr.io/shssoichiro/oxipng:v9.1.3 --opt=4 --preserve --strip=safe -r /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  docs:
+    build:
+      context: .
+    volumes:
+      - ./:/docs
+    ports:
+      - 8000:8000


### PR DESCRIPTION
# Description of the change

I got bored of finding the docker run command in my shell history, so let's instrument docs preview a bit better.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [ ] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [ ] The preview looks fine.
- [ ] The tests pass.
- [ ] The commit history is clean and meaningful.
- [ ] The pull request is opened against the `main` branch.
- [ ] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
