### PR TITLE
Update Teleport integration documentation

### DIFF
--- a/docs/integrations/teleport.md
+++ b/docs/integrations/teleport.md
@@ -220,7 +220,7 @@ the PR you opened.
 You should see a Terraform plan that includes the user and role you defined
 earlier:
 
-!<p align="center">
+<p align="center">
   <img src="../assets/screenshots/teleport-pr-run.png"/>
 </p>
 


### PR DESCRIPTION
model

# Description of the change

We've updated the Teleport Terraform Provider to remove the necessity of the `teleport-spacelift-runner` custom docker image, this is simpler for users & removes our need to maintain an image tracking the Spacelift base docker image.

This PR updates the documentation to leverage the new functionality within the Teleport Terraform Provider and removes the steps to setup the `teleport-spacelift-runner` image.

Related to https://github.com/gravitational/teleport/issues/46425

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [ ] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
