### PR TITLE
fix(integrations): microsoft entra ID warning not rendered

### DIFF
--- a/docs/integrations/single-sign-on/microsoft-entra-id-oidc-setup-guide.md
+++ b/docs/integrations/single-sign-on/microsoft-entra-id-oidc-setup-guide.md
@@ -67,9 +67,9 @@ This allows you to assign permissions to user groups in Spacelift using the **Id
 To enable this, add the `groups` optional claim to the ID token. Most likely, you will want to choose **Security** or **Groups assigned to the application**.
 
 !!! warning
-The number of groups in the ID token cannot exceed 200 (Azure limit related to HTTP header size).
-You may want to use **Application Groups** to avoid hitting the limit.
-That requires a paid Microsoft Entra ID plan and will be discussed later.
+    The number of groups in the ID token cannot exceed 200 (Azure limit related to HTTP header size).
+    You may want to use **Application Groups** to avoid hitting the limit.
+    That requires a paid Microsoft Entra ID plan and will be discussed later.
 
 ![Add groups claim to ID token](<../../assets/screenshots/oidc/microsoft-entra-id-token-configuration-groups-2025-04-08.png>)
 


### PR DESCRIPTION
# Description of the change

Without leading space the warning was rendered empty.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [ ] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [ ] The preview looks fine.
- [ ] The tests pass.
- [ ] The commit history is clean and meaningful.
- [ ] The pull request is opened against the `main` branch.
- [ ] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
