### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/spacelift-io/user-documentation/security/code-scanning/9](https://github.com/spacelift-io/user-documentation/security/code-scanning/9)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not perform any write operations, the `contents: read` permission is sufficient. This limits the `GITHUB_TOKEN` to read-only access to the repository contents, adhering to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs, as none of the jobs require write access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
