### PR TITLE
fix: remove beta warning in integrations docs

### DIFF
--- a/docs/integrations/external-integrations/backstage.md
+++ b/docs/integrations/external-integrations/backstage.md
@@ -1,8 +1,5 @@
 # Backstage
 
-!!! warning
-    This feature is still in beta testing.
-
 ## About the integration
 
 The Backstage integration with Spacelift creates a bridge between your infrastructure as code workflows and Backstage.

--- a/docs/integrations/external-integrations/servicenow.md
+++ b/docs/integrations/external-integrations/servicenow.md
@@ -1,8 +1,5 @@
 # ServiceNow
 
-!!! warning
-    This feature is still in beta testing.
-
 {% if is_saas() %}
 !!! Info
     This feature is only available to Enterprise plan. Please check out our [pricing page](https://spacelift.io/pricing){: rel="nofollow"} for more information.


### PR DESCRIPTION
# Description of the change

Backstage and ServiceNow integrations are no longer in beta stage. 

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
