### PR TITLE
chore: update Ansible specific notif data input docs

### DIFF
--- a/docs/concepts/policy/notification-policy.md
+++ b/docs/concepts/policy/notification-policy.md
@@ -202,6 +202,26 @@ This is the schema of the data input that each policy request can receive:
 
 The final JSON object received as input will depend on the type of notification being sent. Event-dependent objects will only be present when those events happen. The best way to see what input your Notification policy received is to [enable sampling](../policy/README.md#sampling-policy-inputs) and check the [Policy Workbench](../policy/README.md#policy-workbench-in-practice), but you can also use the table below as a reference:
 
+### Ansible vendor changes structure
+
+For Ansible runs, the `changes` array contains objects with different `action` values and `entity` objects that contain Ansible-specific fields:
+
+```json
+"changes": [
+  {
+    "action": "string enum - changed | ok | skipped | rescued | ignored | unreachable | failed",
+    "entity": {
+      "host_name": "string",
+      "playbook_name": "string",
+      "role_name": "string",
+      "task_name": "string",
+      "task_action": "string"
+    },
+    "phase": "string enum - plan | apply"
+  }
+]
+```
+
 | Object Received     | Event                                                                |
 | ------------------- | -------------------------------------------------------------------- |
 | `account`           | Any event                                                            |


### PR DESCRIPTION
Updates notification policy data input documentation to include Ansible specific changes objects.

Part of: https://github.com/spacelift-io/backend/pull/10815

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [x] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
