### PR TITLE
fix: missing GitHub app events in manual setup documentation

### DIFF
--- a/docs/integrations/source-control/github.md
+++ b/docs/integrations/source-control/github.md
@@ -95,6 +95,8 @@ You will be presented with two options:
 
     Subscribe to the following events:
 
+      - Check run
+      - Issue comment
       - Organization
       - Pull request
       - Pull request review


### PR DESCRIPTION
# Description of the change

The manual setup instructions were missing two required events that are present in the wizard mode: "Check run" and "Issue comment". This discrepancy could cause GitHub integrations configured via manual setup to malfunction, as they would not receive necessary webhook events for status checks and pull request comments.

Updated the events list to match the wizard configuration and ensure manual setup works correctly.

See https://spacelift-io.slack.com/archives/C08QU6LJGCX/p1753367752945409

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [ ] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [ ] The preview looks fine.
- [ ] The tests pass.
- [ ] The commit history is clean and meaningful.
- [ ] The pull request is opened against the `main` branch.
- [ ] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
