### PR TITLE
chore: update Kubernetes workers for new pod history management

### DIFF
--- a/docs/concepts/worker-pools/kubernetes-workers.md
+++ b/docs/concepts/worker-pools/kubernetes-workers.md
@@ -382,77 +382,6 @@ To configure the binaries cache volume, you can use exactly the same approach as
 
 See the section on [configuration](#configuration) for more details on how to configure these two volumes along with any additional volumes you require.
 
-## Pod History Management
-
-The Kubernetes operator provides flexible pod history management to control how long completed run pods are retained. This allows you to balance between debugging capabilities and resource usage.
-
-### Overview
-
-The pod history management system supports both count-based and time-based cleanup strategies that work together:
-
-- **Count-based limits**: Control how many completed pods to keep per worker
-- **Time-based cleanup (TTL)**: Automatically remove pods after a specified duration
-- **Combined strategy**: Pods are removed when they exceed **either** the count limit **or** the time limit
-
-### Default Behavior
-
-- **Successful pods**: Removed immediately (limit: 0)  
-- **Failed pods**: Keep 5 most recent (limit: 5)
-- **Time limits**: No automatic TTL cleanup (unless explicitly configured)
-
-### Configuration Options
-
-#### Count-Based Limits
-
-```yaml
-spec:
-  # Keep 3 most recent successful pods per individual worker
-  successfulPodsHistoryLimit: 3
-  
-  # Keep 10 most recent failed pods per individual worker  
-  failedPodsHistoryLimit: 10
-```
-
-#### Time-Based Cleanup (TTL)
-
-```yaml
-spec:
-  # Remove successful pods older than 24 hours
-  successfulPodsHistoryTTL: "24h"
-  
-  # Remove failed pods older than 72 hours
-  failedPodsHistoryTTL: "72h"
-```
-
-#### Special Modes
-
-**Delete-All Mode**: Set limit to 0 to remove all pods immediately
-
-```yaml
-spec:
-  successfulPodsHistoryLimit: 0  # Remove all successful pods immediately
-  failedPodsHistoryLimit: 0      # Remove all failed pods immediately
-```
-
-**TTL-Only Mode**: Set TTL without limit for time-based cleanup only
-
-```yaml
-spec:
-  # Only time-based cleanup, no count limits
-  successfulPodsHistoryTTL: "48h"
-  # successfulPodsHistoryLimit is intentionally unset
-```
-
-### Behavior Details
-
-- **Pod selection**: Uses creation time for consistent ordering (oldest removed first)
-- **Running pods**: Never affected by cleanup, only applies to completed pods
-- **WorkerPool scope**: Cleanup is managed centrally at the WorkerPool level across all workers in the pool
-- **Deletion safety**: Pods already being deleted are excluded from counts
-
-!!! note "Migration from keepSuccessfulPods"
-    The `keepSuccessfulPods` field has been deprecated since controller version v0.0.25 and Helm chart version 0.8.0, and has been removed in favor of the new pod history management system. If you previously used `keepSuccessfulPods: true`, set `successfulPodsHistoryLimit` to a positive value instead.
-
 ## Configuration
 
 The following example shows all the configurable options for a WorkerPool:
@@ -658,6 +587,77 @@ spec:
       - name: redis
         image: redis
 ```
+
+### Pod History Management
+
+The Kubernetes operator provides flexible pod history management to control how long completed run pods are retained. This allows you to balance between debugging capabilities and resource usage.
+
+#### Overview
+
+The pod history management system supports both count-based and time-based cleanup strategies that work together:
+
+- **Count-based limits**: Control how many completed pods to keep per worker
+- **Time-based cleanup (TTL)**: Automatically remove pods after a specified duration
+- **Combined strategy**: Pods are removed when they exceed **either** the count limit **or** the time limit
+
+#### Default Behavior
+
+- **Successful pods**: Removed immediately (limit: 0)  
+- **Failed pods**: Keep 5 most recent (limit: 5)
+- **Time limits**: No automatic TTL cleanup (unless explicitly configured)
+
+#### Configuration Options
+
+##### Count-Based Limits
+
+```yaml
+spec:
+  # Keep 3 most recent successful pods per individual worker
+  successfulPodsHistoryLimit: 3
+  
+  # Keep 10 most recent failed pods per individual worker  
+  failedPodsHistoryLimit: 10
+```
+
+##### Time-Based Cleanup (TTL)
+
+```yaml
+spec:
+  # Remove successful pods older than 24 hours
+  successfulPodsHistoryTTL: "24h"
+  
+  # Remove failed pods older than 72 hours
+  failedPodsHistoryTTL: "72h"
+```
+
+##### Special Modes
+
+**Delete-All Mode**: Set limit to 0 to remove all pods immediately
+
+```yaml
+spec:
+  successfulPodsHistoryLimit: 0  # Remove all successful pods immediately
+  failedPodsHistoryLimit: 0      # Remove all failed pods immediately
+```
+
+**TTL-Only Mode**: Set TTL without limit for time-based cleanup only
+
+```yaml
+spec:
+  # Only time-based cleanup, no count limits
+  successfulPodsHistoryTTL: "48h"
+  # successfulPodsHistoryLimit is intentionally unset
+```
+
+#### Behavior Details
+
+- **Pod selection**: Uses creation time for consistent ordering (oldest removed first)
+- **Running pods**: Never affected by cleanup, only applies to completed pods
+- **WorkerPool scope**: Cleanup is managed centrally at the WorkerPool level across all workers in the pool
+- **Deletion safety**: Pods already being deleted are excluded from counts
+
+!!! note "Migration from keepSuccessfulPods"
+    The `keepSuccessfulPods` field has been deprecated since controller version v0.0.25 and Helm chart version 0.8.0, and has been removed in favor of the new pod history management system. If you previously used `keepSuccessfulPods: true`, set `successfulPodsHistoryLimit` to a positive value instead.
 
 ### Configure a docker daemon as a sidecar container
 

--- a/docs/concepts/worker-pools/kubernetes-workers.md
+++ b/docs/concepts/worker-pools/kubernetes-workers.md
@@ -382,6 +382,77 @@ To configure the binaries cache volume, you can use exactly the same approach as
 
 See the section on [configuration](#configuration) for more details on how to configure these two volumes along with any additional volumes you require.
 
+## Pod History Management
+
+The Kubernetes operator provides flexible pod history management to control how long completed run pods are retained. This allows you to balance between debugging capabilities and resource usage.
+
+### Overview
+
+The pod history management system supports both count-based and time-based cleanup strategies that work together:
+
+- **Count-based limits**: Control how many completed pods to keep per worker
+- **Time-based cleanup (TTL)**: Automatically remove pods after a specified duration
+- **Combined strategy**: Pods are removed when they exceed **either** the count limit **or** the time limit
+
+### Default Behavior
+
+- **Successful pods**: Removed immediately (limit: 0)  
+- **Failed pods**: Keep 5 most recent (limit: 5)
+- **Time limits**: No automatic TTL cleanup (unless explicitly configured)
+
+### Configuration Options
+
+#### Count-Based Limits
+
+```yaml
+spec:
+  # Keep 3 most recent successful pods per individual worker
+  successfulPodsHistoryLimit: 3
+  
+  # Keep 10 most recent failed pods per individual worker  
+  failedPodsHistoryLimit: 10
+```
+
+#### Time-Based Cleanup (TTL)
+
+```yaml
+spec:
+  # Remove successful pods older than 24 hours
+  successfulPodsHistoryTTL: "24h"
+  
+  # Remove failed pods older than 72 hours
+  failedPodsHistoryTTL: "72h"
+```
+
+#### Special Modes
+
+**Delete-All Mode**: Set limit to 0 to remove all pods immediately
+
+```yaml
+spec:
+  successfulPodsHistoryLimit: 0  # Remove all successful pods immediately
+  failedPodsHistoryLimit: 0      # Remove all failed pods immediately
+```
+
+**TTL-Only Mode**: Set TTL without limit for time-based cleanup only
+
+```yaml
+spec:
+  # Only time-based cleanup, no count limits
+  successfulPodsHistoryTTL: "48h"
+  # successfulPodsHistoryLimit is intentionally unset
+```
+
+### Behavior Details
+
+- **Pod selection**: Uses creation time for consistent ordering (oldest removed first)
+- **Running pods**: Never affected by cleanup, only applies to completed pods
+- **WorkerPool scope**: Cleanup is managed centrally at the WorkerPool level across all workers in the pool
+- **Deletion safety**: Pods already being deleted are excluded from counts
+
+!!! note "Migration from keepSuccessfulPods"
+    The `keepSuccessfulPods` field has been deprecated since controller version v0.0.25 and Helm chart version 0.8.0, and has been removed in favor of the new pod history management system. If you previously used `keepSuccessfulPods: true`, set `successfulPodsHistoryLimit` to a positive value instead.
+
 ## Configuration
 
 The following example shows all the configurable options for a WorkerPool:
@@ -418,12 +489,42 @@ spec:
     - docker.io
     - some.private.registry
 
-  # keepSuccessfulPods indicates whether run Pods should automatically be removed as soon
-  # as they complete successfully, or be kept so that they can be inspected later. By default
-  # run Pods are removed as soon as they complete successfully. Failed Pods are not automatically
-  # removed to allow debugging.
+  # Pod history management configuration
+  # These settings control how many completed pods are retained and for how long
+  
+  # successfulPodsHistoryLimit specifies the number of successful Pods to keep for inspection purposes.
+  # When set to a positive number, only the N most recent successful Pods are kept per worker.
+  # When set to 0, all successful Pods are removed immediately.
+  # When unset and successfulPodsHistoryTTL is also unset, defaults to 0 (remove all).
+  # When unset but successfulPodsHistoryTTL is set, count-based cleanup is disabled (TTL-only).
   # Optional
-  keepSuccessfulPods: false
+  successfulPodsHistoryLimit: 0
+  
+  # failedPodsHistoryLimit specifies the number of failed Pods to keep for debugging purposes.
+  # When set to a positive number, only the N most recent failed Pods are kept per worker.
+  # When set to 0, all failed Pods are removed immediately.
+  # When unset and failedPodsHistoryTTL is also unset, defaults to 5 (keep 5 most recent).
+  # When unset but failedPodsHistoryTTL is set, count-based cleanup is disabled (TTL-only).
+  # Optional
+  failedPodsHistoryLimit: 5
+  
+  # successfulPodsHistoryTTL specifies the duration to keep successful Pods after they are created.
+  # When set, successful Pods that have been created for longer than this duration are removed.
+  # The TTL timer starts from Pod creation time for consistency with history limit ordering.
+  # Running pods are never affected by this TTL.
+  # When unset (nil), no time-based cleanup is performed for successful Pods.
+  # This works in combination with successfulPodsHistoryLimit - pods are removed if they exceed EITHER limit.
+  # Optional
+  successfulPodsHistoryTTL: "24h"
+  
+  # failedPodsHistoryTTL specifies the duration to keep failed Pods after they are created.
+  # When set, failed Pods that have been created for longer than this duration are removed.
+  # The TTL timer starts from Pod creation time for consistency with history limit ordering.
+  # Running pods are never affected by this TTL.
+  # When unset (nil), no time-based cleanup is performed for failed Pods.
+  # This works in combination with failedPodsHistoryLimit - pods are removed if they exceed EITHER limit.
+  # Optional
+  failedPodsHistoryTTL: "72h"
 
   # pod contains the spec of Pods that will be created to process Spacelift runs. This allows
   # you to set things like custom resource requests and limits, volumes, and service accounts.
@@ -1158,21 +1259,6 @@ Please also include your controller logs from 10 minutes before the run started.
 Please note that if you are using a custom runner image for your stack, it **must** include a Spacelift user with a UID of 1983. If your image does not include this user, it can cause permission issues during runs, for example while trying to write out configuration files while preparing the run.
 
 Please see our [instructions on customizing the runner image](../../integrations/docker.md#customizing-the-runner-image) for more information.
-
-### Inspecting successful run pods
-
-By default, the operator deletes the pods for successful runs as soon as they complete. If you need to inspect a pod after the run has completed successfully for debugging purposes, you can enable `spec.keepSuccessfulPods`:
-
-```yaml
-apiVersion: workers.spacelift.io/v1beta1
-kind: WorkerPool
-metadata:
-  name: test-workerpool
-spec:
-  ...
-
-  keepSuccessfulPods: true
-```
 
 ### Networking issues caused by Pod identity
 


### PR DESCRIPTION
# Description of the change

Add documentation for successfulPodsHistoryLimit, failedPodsHistoryLimit, successfulPodsHistoryTTL, and failedPodsHistoryTTL fields. Include examples for different cleanup modes and clarify that limits apply per worker

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [x] The preview looks fine.
- [x] The tests pass.
- [x] The commit history is clean and meaningful.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
