### PR TITLE
Move VCS agent pools navigation location

### DIFF
--- a/nav.self-hosted.yaml
+++ b/nav.self-hosted.yaml
@@ -101,6 +101,7 @@ nav:
           - concepts/worker-pools/docker-based-workers.md
           - concepts/worker-pools/kubernetes-workers.md
       - concepts/spacectl.md
+      - concepts/vcs-agent-pools.md
       - Spaces:
           - concepts/spaces/README.md
           - concepts/spaces/access-control.md
@@ -114,7 +115,6 @@ nav:
           - concepts/user-management/README.md
           - concepts/user-management/admin.md
           - concepts/user-management/user.md
-      - concepts/vcs-agent-pools.md
   - 🛰️ Platforms:
       - Terraform:
           - vendors/terraform/README.md

--- a/nav.yaml
+++ b/nav.yaml
@@ -68,6 +68,7 @@ nav:
           - concepts/worker-pools/docker-based-workers.md
           - concepts/worker-pools/kubernetes-workers.md
       - concepts/spacectl.md
+      - concepts/vcs-agent-pools.md
       - Spaces:
           - concepts/spaces/README.md
           - concepts/spaces/access-control.md
@@ -89,7 +90,6 @@ nav:
           - concepts/user-management/README.md
           - concepts/user-management/admin.md
           - concepts/user-management/user.md
-      - concepts/vcs-agent-pools.md
   - 🛰️ Platforms:
       - Terraform:
           - vendors/terraform/README.md


### PR DESCRIPTION
# Description of the change

https://docs.spacelift.io/self-hosted/latest/sitemap.xml
vcs agent pool is not showing in the sitemap.
trying to figure out why.