### PR TITLE
Add the policy contract information to each input example

### DIFF
--- a/docs/concepts/policy/README.md
+++ b/docs/concepts/policy/README.md
@@ -37,6 +37,7 @@ Please refer to the following table for information on what each policy types re
 
 !!! tip
     We maintain a [library of example policies](https://github.com/spacelift-io/spacelift-policies-example-library){: rel="nofollow"} that are ready to use or that you could tweak to meet your specific needs.
+    For up to date policy input information you can also refer to [official Spacelift policy contract schema](https://app.spacelift.tf/.well-known/policy-contract.json){:+ rel="nofollow"}.
 
     If you cannot find what you are looking for, please reach out to [our support](../../product/support/README.md#contact-support) and we will craft a policy to do exactly what you need.
 

--- a/docs/concepts/policy/approval-policy.md
+++ b/docs/concepts/policy/approval-policy.md
@@ -52,6 +52,9 @@ When a user reviews the run, Spacelift persists their review and passes it to th
 
 This is the schema of the data input that each policy request will receive:
 
+!!! tip "Official Schema Reference"
+    For the most up-to-date and complete schema definition, please refer to the [official Spacelift policy contract schema](https://app.spacelift.tf/.well-known/policy-contract.json){: rel="nofollow"} under the `APPROVAL` policy type.
+
 ```json
 {
   "reviews": { // run reviews

--- a/docs/concepts/policy/login-policy.md
+++ b/docs/concepts/policy/login-policy.md
@@ -51,6 +51,9 @@ Admins have significant privileges and can create and delete stacks; trigger run
 
 Each policy request will receive this data input:
 
+!!! tip "Official Schema Reference"
+    For the most up-to-date and complete schema definition, please refer to the [official Spacelift policy contract schema](https://app.spacelift.tf/.well-known/policy-contract.json){: rel="nofollow"} under the `LOGIN` policy type.
+
 ```json title="data_input_schema.json"
 {
   "request": {

--- a/docs/concepts/policy/notification-policy.md
+++ b/docs/concepts/policy/notification-policy.md
@@ -22,6 +22,9 @@ If no rules match, no action is taken.
 
 This is the schema of the data input that each policy request can receive:
 
+!!! tip "Official Schema Reference"
+    For the most up-to-date and complete schema definition, please refer to the [official Spacelift policy contract schema](https://app.spacelift.tf/.well-known/policy-contract.json){: rel="nofollow"} under the `NOTIFICATION` policy type.
+
 ```json
 {
   "account": {

--- a/docs/concepts/policy/push-policy/README.md
+++ b/docs/concepts/policy/push-policy/README.md
@@ -324,6 +324,9 @@ Each source control provider has slightly different features, and because of thi
 
 As input, Git push policy receives the following document:
 
+!!! tip "Official Schema Reference"
+    For the most up-to-date and complete schema definition, please refer to the [official Spacelift policy contract schema](https://app.spacelift.tf/.well-known/policy-contract.json){: rel="nofollow"} under the `GIT_PUSH` policy type.
+
 ```json
 {
   "in_progress": [{

--- a/docs/concepts/policy/stack-access-policy.md
+++ b/docs/concepts/policy/stack-access-policy.md
@@ -40,6 +40,9 @@ Last but not least the third group - folks who build things on top of existing i
 
 This is the schema of the data input that each policy request will receive:
 
+!!! tip "Official Schema Reference"
+    For the most up-to-date and complete schema definition, please refer to the [official Spacelift policy contract schema](https://app.spacelift.tf/.well-known/policy-contract.json){: rel="nofollow"} under the `ACCESS` policy type.
+
 ```json
 {
   "request": {

--- a/docs/concepts/policy/task-run-policy.md
+++ b/docs/concepts/policy/task-run-policy.md
@@ -28,6 +28,9 @@ And here's the outcome when trying to run a task:
 
 This is the schema of the data input that each policy request will receive:
 
+!!! tip "Official Schema Reference"
+    For the most up-to-date and complete schema definition, please refer to the [official Spacelift policy contract schema](https://app.spacelift.tf/.well-known/policy-contract.json){: rel="nofollow"} under the `TASK` policy type.
+
 ```json
 {
   "request": {

--- a/docs/concepts/policy/terraform-plan-policy.md
+++ b/docs/concepts/policy/terraform-plan-policy.md
@@ -32,6 +32,9 @@ Yay, that works (and it fails our plan, too), but it's not terribly useful - unl
 This is the schema of the data input that each policy request will receive.
 If the policy is executed for the first time, the `previous_run` field will be missing.
 
+!!! tip "Official Schema Reference"
+    For the most up-to-date and complete schema definition, please refer to the [official Spacelift policy contract schema](https://app.spacelift.tf/.well-known/policy-contract.json){: rel="nofollow"} under the `PLAN` policy type.
+
 ```json
 {
   "spacelift": {

--- a/docs/concepts/policy/trigger-policy.md
+++ b/docs/concepts/policy/trigger-policy.md
@@ -22,6 +22,9 @@ All runs triggered - directly or indirectly - by trigger policies as a result of
 
 When triggered by a _run_, this is the schema of the data input that each policy request will receive:
 
+!!! tip "Official Schema Reference"
+    For the most up-to-date and complete schema definition, please refer to the [official Spacelift policy contract schema](https://app.spacelift.tf/.well-known/policy-contract.json){: rel="nofollow"} under the `TRIGGER` policy type.
+
 ```json
 {
   "run": {


### PR DESCRIPTION
# Description of the change

Ideally we would generate the input and replace the current input examples with that, but the json schema is awful to read by a human, so we'd have to invent some kind of conversion. We'd also need to write a bunch of custom commit hooks in python. I suggest that this is good enough for now.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [ ] I have reviewed the [guidelines for contributing](https://github.com/spacelift-io/user-documentation/blob/main/CONTRIBUTING.md) to this repository.
- [ ] The preview looks fine.
- [ ] The tests pass.
- [ ] The commit history is clean and meaningful.
- [ ] The pull request is opened against the `main` branch.
- [ ] The pull request is no longer marked as a draft.
- [ ] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/user-documentation/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).
- You have updated the navigation files correctly:
    - [ ] No new pages have been added, or;
    - [ ] Only _nav.yaml_ has been updated because the changes only apply to SaaS, or;
    - [ ] Only _nav.self-hosted.yaml_ has been updated because the changes only apply to Self-Hosted, or;
    - [ ] Both _nav.yaml_ and _nav.self-hosted.yaml_ have been updated.

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
