### PR TITLE
feat: update changelog to reflect new provider resource

### DIFF
--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -4,6 +4,12 @@ description: Find out about the latest changes to Spacelift.
 
 # Changelog
 
+## 2025-10-03
+
+## Features
+
+- You can now create API keys via the TF provider. See the [API keys resource documentation](https://search.opentofu.org/provider/spacelift-io/spacelift/latest/docs/resources/api_key) for more information.
+
 ## 2025-10-01
 
 ### Features


### PR DESCRIPTION
This PR will need updated with versions before merging once this is released and ready to go.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Announces ability to create API keys via the TF provider and updates the self-hosted Terraform provider compatibility matrix for 3.5.x.
> 
> - **Changelogs**:
>   - `docs/installing-spacelift/changelog.md`: Add section for `v3.5.x → v3.5.0` noting API keys can be created via the TF provider (link to resource docs).
>   - `docs/product/changelog.md`: Add `2025-09-29` entry announcing API key creation via the TF provider.
> - **Terraform Provider Docs**:
>   - `docs/vendors/terraform/terraform-provider.md`: Update Self-Hosted compatibility table to include `3.5.x → 1.3x.x`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4964d4203b9105fadb0e3cc1f414890dee057927. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->