### PR TITLE
Move Role Based Access Control changelog entry to the correct version

### DIFF
--- a/docs/installing-spacelift/changelog.md
+++ b/docs/installing-spacelift/changelog.md
@@ -10,13 +10,13 @@ description: Find out about the latest changes to the Self-Hosted Spacelift.
 
 - Run details now display both the API key ID and name when triggered by an API key. Previously only the key ID was shown, which made it difficult to identify which key was used. The key ID is shown in shortened format. For example: `api::01K56PK::DevopsSpaceKey`.
 - Added Samples section in policy view, which offers powerful filtering options to help quickly locate relevant samples
+- [Role Based Access Control](../concepts/spaces/access-control.md) is now available for self-hosted distributions
 
 ## Changes between v3.4.0 and v3.3.0
 
 ### Features
 
 - [Support for VCS agent pools for self-hosted distributions](../concepts/vcs-agent-pools.md): [installation instruction](../installing-spacelift/reference-architecture/guides/deploying-to-ecs.md#vcs-gateway-service)
-- [Role Based Access Control](../concepts/spaces/access-control.md) is now available for self-hosted distributions
 - [OIDC configuration options are now configurable](../integrations/cloud-providers/oidc/README.md#overriding-issuer-and-jwks-endpoints-self-hosted) (`issuer` and `jwks_uri`)
 - [Exposed a new configuration value](../installing-spacelift/reference-architecture/guides/observability.md#message-queues) for the message queue:
     - `MESSAGE_PROCESSING_TIMEOUT_SECONDS` environment variable controls how long messages can be processed before timing out (default: 900 seconds). Reducing this value (e.g., to 300 seconds) causes long-running messages to return to the queue faster, allowing other messages to be processed.


### PR DESCRIPTION
# Description of the change

We should have removed it earlier. Now we should move it to the correct changelog diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves the RBAC availability note from `v3.5.0–v3.4.0` to `v3.4.0–v3.3.0` in `docs/installing-spacelift/changelog.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3029d551dddecc0c02a3f5fb4309150c47c45f2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->