### PR TITLE
add customizable run log retention documentation

### DIFF
--- a/docs/concepts/run/README.md
+++ b/docs/concepts/run/README.md
@@ -156,7 +156,36 @@ Stopped is a _passive state_ meaning no operations are performed while a run is 
 
 ## Logs Retention
 
-Run logs are kept for 60 days.
+{% if is_saas() %}
+
+Run logs are kept for a configurable retention period. By default, all accounts have a retention period of **60 days**.
+
+## Viewing Current Retention Period
+
+You can view your current run logs retention period in the Spacelift UI by navigating to **Organization Settings** and selecting the **Limits** section.
+
+## Customizable Retention Periods
+
+The logs retention period can be customized to one of the following options:
+
+- **60 days** (default)
+- **90 days**
+- **180 days**
+- **365 days**
+- **730 days**
+
+To modify your retention period, please contact your customer representative who can configure this setting for your account.
+
+## Important Considerations
+
+Changing the retention period will not retroactively apply to existing runs. The new retention period will only take effect for runs created after the change has been made. Previously created runs will continue to follow the retention period that was active when they were created.
+
+{% else %}
+
+Run logs are kept for a configurable retention period. By default, run logs have a retention period of **60 days**.
+[If there's a need to customize the retention period, you can do so by configuring a custom S3 bucket configuration for the run logs.](https://github.com/spacelift-io/terraform-aws-spacelift-selfhosted?tab=readme-ov-file#deploy-with-custom-s3-bucket-retention)
+
+{% endif %}
 
 ## Run prioritization
 

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -4,6 +4,12 @@ description: Find out about the latest changes to Spacelift.
 
 # Changelog
 
+## 2025-10-01
+
+### Features
+
+- Run log rentention period can now be configured at the organization level. This allows you to set how long run logs are retained before being automatically deleted. More details can be found in the [run log retention documentation](../../concepts/run#logs-retention).
+
 ## 2025-09-30
 
 ### Features

--- a/docs/product/changelog.md
+++ b/docs/product/changelog.md
@@ -8,7 +8,7 @@ description: Find out about the latest changes to Spacelift.
 
 ### Features
 
-- Run log rentention period can now be configured at the organization level. This allows you to set how long run logs are retained before being automatically deleted. More details can be found in the [run log retention documentation](../../concepts/run#logs-retention).
+- Run log retention period can now be configured at the organization level. This allows you to set how long run logs are retained before being automatically deleted. More details can be found in the [run log retention documentation](../../concepts/run#logs-retention).
 
 ## 2025-09-30
 


### PR DESCRIPTION
# Description of the change

- Add customizable run log retention documention
- Add changelog entry

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents configurable run log retention (SaaS and self-hosted) and adds a changelog entry announcing org-level retention configuration.
> 
> - **Docs**:
>   - Update `docs/concepts/run/README.md` to make run log retention configurable.
>     - *SaaS*: Default **60 days**; options: 60/90/180/365/730 days; view under `Organization Settings > Limits`; changes apply only to new runs; contact representative to modify.
>     - *Self-hosted*: Default **60 days**; customization via custom S3 bucket retention with link to configuration.
> - **Changelog**:
>   - Add `docs/product/changelog.md` entry for `2025-10-01` announcing org-level configurable run log retention with link to the retention docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e4e7588c493bb59e69e3b9dd9024b984d6a9881. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->